### PR TITLE
feat(withRedirections): add config.withRedirections

### DIFF
--- a/e2e/templates/simple/kosko generate/__tests__/__snapshots__/--env prod.ts.snap
+++ b/e2e/templates/simple/kosko generate/__tests__/__snapshots__/--env prod.ts.snap
@@ -449,6 +449,27 @@ apiVersion: apps/v1
 kind: Deployment
 ---
 metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/permanent-redirect: 'https://www.website.fr$request_uri'
+    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    kubernetes.io/tls-acme: 'true'
+  labels:
+    app: www-redirects
+  name: www-redirects
+spec:
+  rules:
+    - host: website.fr
+    - host: old-website.com
+  tls:
+    - hosts:
+        - website.fr
+        - old-website.com
+      secretName: www-redirects
+apiVersion: extensions/v1beta1
+kind: Ingress
+---
+metadata:
   labels:
     app: www
     application: sample-kosko

--- a/src/utils/createIngress.ts
+++ b/src/utils/createIngress.ts
@@ -6,7 +6,7 @@ export interface IngressConfig {
   serviceName?: string;
   servicePort?: number;
   secretName?: string;
-  annotations?: object;
+  annotations?: Record<string, unknown>;
 }
 
 const getHostService = ({ serviceName = "app", servicePort = 3000 }) => ({

--- a/src/utils/createIngress.ts
+++ b/src/utils/createIngress.ts
@@ -3,21 +3,41 @@ import { Ingress } from "kubernetes-models/extensions/v1beta1/Ingress";
 export interface IngressConfig {
   name: string;
   hosts: string[];
-  serviceName: string;
-  servicePort: number;
+  serviceName?: string;
+  servicePort?: number;
   secretName?: string;
+  annotations?: object;
 }
+
+const getHostService = ({ serviceName = "app", servicePort = 3000 }) => ({
+  http: {
+    paths: [
+      {
+        backend: {
+          serviceName,
+          servicePort,
+        },
+        path: "/",
+      },
+    ],
+  },
+});
 
 export default (params: IngressConfig): Ingress => {
   const hosts = params.hosts;
   const annotations: Record<string, string> = {
     "kubernetes.io/ingress.class": "nginx",
+    ...(params.annotations || {}),
   };
   if (process.env.PRODUCTION) {
     annotations["certmanager.k8s.io/cluster-issuer"] = "letsencrypt-prod";
     annotations["kubernetes.io/tls-acme"] = "true";
   }
-  return new Ingress({
+  const isRedirectionIngress = !!annotations[
+    "nginx.ingress.kubernetes.io/permanent-redirect"
+  ];
+
+  const ingressDefinition = {
     metadata: {
       annotations,
       labels: {
@@ -28,17 +48,13 @@ export default (params: IngressConfig): Ingress => {
     spec: {
       rules: hosts.map((host) => ({
         host,
-        http: {
-          paths: [
-            {
-              backend: {
-                serviceName: params.serviceName,
-                servicePort: params.servicePort,
-              },
-              path: "/",
-            },
-          ],
-        },
+        // when redirecting, we dont need to map the service
+        ...(isRedirectionIngress
+          ? {}
+          : getHostService({
+              serviceName: params.serviceName,
+              servicePort: params.servicePort,
+            })),
       })),
       tls: [
         {
@@ -49,5 +65,7 @@ export default (params: IngressConfig): Ingress => {
         },
       ],
     },
-  });
+  };
+
+  return new Ingress(ingressDefinition);
 };

--- a/src/utils/createIngress.ts
+++ b/src/utils/createIngress.ts
@@ -27,7 +27,7 @@ export default (params: IngressConfig): Ingress => {
   const hosts = params.hosts;
   const annotations: Record<string, string> = {
     "kubernetes.io/ingress.class": "nginx",
-    ...(params.annotations || {}),
+    ...(params.annotations ?? {}),
   };
   if (process.env.PRODUCTION) {
     annotations["certmanager.k8s.io/cluster-issuer"] = "letsencrypt-prod";

--- a/templates/simple/components/www.ts
+++ b/templates/simple/components/www.ts
@@ -17,6 +17,10 @@ const manifests = create("www", {
     },
     containerPort: 8080,
     withPostgres: true,
+    withRedirections: {
+      destination: "www.website.fr",
+      hosts: ["website.fr", "old-website.com"],
+    },
   },
   deployment: {
     imagePullSecrets: [


### PR DESCRIPTION
Following #199 

This add a `withRedirections` option to handle more hostnames and 301 redirects

```js
withRedirections: {
  destination: "www.website.fr",
  hosts: ["website.fr", "old-website.com"],
}
```