### PR TITLE
fix(service): add default service.port.name=http

### DIFF
--- a/e2e/templates/simple/kosko generate/__tests__/__snapshots__/--env dev.ts.snap
+++ b/e2e/templates/simple/kosko generate/__tests__/__snapshots__/--env dev.ts.snap
@@ -131,6 +131,7 @@ spec:
   ports:
     - port: 80
       targetPort: 80
+      name: http
   selector:
     app: hasura
   type: ClusterIP
@@ -245,6 +246,7 @@ spec:
   ports:
     - port: 80
       targetPort: 8081
+      name: http
   selector:
     app: pgweb
   type: ClusterIP
@@ -374,6 +376,7 @@ spec:
   ports:
     - port: 80
       targetPort: 6379
+      name: http
   selector:
     app: redis
   type: ClusterIP
@@ -493,6 +496,7 @@ spec:
   ports:
     - port: 80
       targetPort: 8080
+      name: http
   selector:
     app: www
   type: ClusterIP

--- a/e2e/templates/simple/kosko generate/__tests__/__snapshots__/--env preprod.ts.snap
+++ b/e2e/templates/simple/kosko generate/__tests__/__snapshots__/--env preprod.ts.snap
@@ -131,6 +131,7 @@ spec:
   ports:
     - port: 80
       targetPort: 80
+      name: http
   selector:
     app: hasura
   type: ClusterIP
@@ -245,6 +246,7 @@ spec:
   ports:
     - port: 80
       targetPort: 8081
+      name: http
   selector:
     app: pgweb
   type: ClusterIP
@@ -374,6 +376,7 @@ spec:
   ports:
     - port: 80
       targetPort: 6379
+      name: http
   selector:
     app: redis
   type: ClusterIP
@@ -493,6 +496,7 @@ spec:
   ports:
     - port: 80
       targetPort: 8080
+      name: http
   selector:
     app: www
   type: ClusterIP

--- a/e2e/templates/simple/kosko generate/__tests__/__snapshots__/--env prod.ts.snap
+++ b/e2e/templates/simple/kosko generate/__tests__/__snapshots__/--env prod.ts.snap
@@ -110,6 +110,7 @@ spec:
   ports:
     - port: 80
       targetPort: 80
+      name: http
   selector:
     app: hasura
   type: ClusterIP
@@ -221,6 +222,7 @@ spec:
   ports:
     - port: 80
       targetPort: 8081
+      name: http
   selector:
     app: pgweb
   type: ClusterIP
@@ -348,6 +350,7 @@ spec:
   ports:
     - port: 80
       targetPort: 6379
+      name: http
   selector:
     app: redis
   type: ClusterIP
@@ -485,6 +488,7 @@ spec:
   ports:
     - port: 80
       targetPort: 8080
+      name: http
   selector:
     app: www
   type: ClusterIP

--- a/src/utils/createService.ts
+++ b/src/utils/createService.ts
@@ -9,7 +9,12 @@ export interface Params {
   servicePort: number;
   containerPort: number;
   selector: { [key: string]: string };
+  portName?: string;
 }
+
+const defaultParams = {
+  portName: "http",
+};
 
 export default (params: Params): Service => {
   //  const metadata = metadataFromParams(params);
@@ -26,6 +31,7 @@ export default (params: Params): Service => {
         {
           port: params.servicePort,
           targetPort: params.containerPort,
+          name: params.portName || "http",
         },
       ],
       selector: params.selector,

--- a/src/utils/createService.ts
+++ b/src/utils/createService.ts
@@ -12,10 +12,6 @@ export interface Params {
   portName?: string;
 }
 
-const defaultParams = {
-  portName: "http",
-};
-
 export default (params: Params): Service => {
   //  const metadata = metadataFromParams(params);
 
@@ -31,7 +27,7 @@ export default (params: Params): Service => {
         {
           port: params.servicePort,
           targetPort: params.containerPort,
-          name: params.portName || "http",
+          name: params.portName ?? "http",
         },
       ],
       selector: params.selector,


### PR DESCRIPTION
Looks like we need a port name to accept a ServiceMonitor https://github.com/prometheus-operator/prometheus-operator/issues/416