### PR TITLE
fix(azure-db): run create-db jobs in project secret namespace

### DIFF
--- a/src/components/azure-pg/__snapshots__/index.test.ts.snap
+++ b/src/components/azure-pg/__snapshots__/index.test.ts.snap
@@ -34,7 +34,7 @@ Array [
         "team": "sample",
       },
       "name": "create-db-job-abcdefg",
-      "namespace": "sample-42-my-test",
+      "namespace": "sample-secret",
     },
     "spec": Object {
       "backoffLimit": 0,
@@ -134,18 +134,7 @@ Array [
 ]
 `;
 
-exports[`should throw because of a missing envs 1`] = `
-"BadArgument:required property \\"CI_ENVIRONMENT_NAME\\"
-└─ cannot decode undefined, should be string
-required property \\"CI_ENVIRONMENT_SLUG\\"
-└─ cannot decode undefined, should be string
-required property \\"CI_PROJECT_PATH_SLUG\\"
-└─ cannot decode undefined, should be string
-required property \\"KUBE_INGRESS_BASE_DOMAIN\\"
-└─ cannot decode undefined, should be string
-required property \\"KUBE_NAMESPACE\\"
-└─ cannot decode undefined, should be string"
-`;
+exports[`should throw because of a missing envs 1`] = `"Missing process.env.CI_COMMIT_SHORT_SHA"`;
 
 exports[`should use custom pgHost 1`] = `
 Array [
@@ -181,7 +170,7 @@ Array [
         "team": "sample-next-app",
       },
       "name": "create-db-job-abcdefg",
-      "namespace": "sample-42-my-test",
+      "namespace": "sample-next-app-secret",
     },
     "spec": Object {
       "backoffLimit": 0,

--- a/src/components/azure-pg/index.test.ts
+++ b/src/components/azure-pg/index.test.ts
@@ -16,10 +16,10 @@ const gitlabEnv = {
   KUBE_NAMESPACE: "sample-42-my-test",
 };
 
-test("should throw because of a missing CI_PROJECT_NAME", () => {
+test("should throw because of a missing CI_COMMIT_SHORT_SHA", () => {
   const env = new Environment("/tmp");
   expect(() => create({ env })).toThrowError(
-    "Missing process.env.CI_PROJECT_NAME"
+    "Missing process.env.CI_COMMIT_SHORT_SHA"
   );
 });
 


### PR DESCRIPTION
when using `kosko-charts/azure-pg/create()` the `create-db` job used in development will now run in the `project-secret` namespace where `azure-admin-pg-user` secret resides.

this removes the necessity to get the secret from the repo (sealed-secret) or copy it to some namespace