### PR TITLE
feat(azure-pg): add uuid-ossp extension on create

### DIFF
--- a/src/components/azure-pg/__snapshots__/create-db.test.ts.snap
+++ b/src/components/azure-pg/__snapshots__/create-db.test.ts.snap
@@ -91,7 +91,7 @@ Object {
               },
               Object {
                 "name": "NEW_DB_EXTENSIONS",
-                "value": "hstore pgcrypto citext",
+                "value": "hstore pgcrypto citext uuid-ossp",
               },
             ],
             "envFrom": Array [

--- a/src/components/azure-pg/__snapshots__/index.test.ts.snap
+++ b/src/components/azure-pg/__snapshots__/index.test.ts.snap
@@ -55,7 +55,7 @@ Array [
                 },
                 Object {
                   "name": "NEW_DB_EXTENSIONS",
-                  "value": "hstore pgcrypto citext",
+                  "value": "hstore pgcrypto citext uuid-ossp",
                 },
               ],
               "envFrom": Array [
@@ -175,7 +175,7 @@ Array [
                 },
                 Object {
                   "name": "NEW_DB_EXTENSIONS",
-                  "value": "hstore pgcrypto citext",
+                  "value": "hstore pgcrypto citext uuid-ossp",
                 },
               ],
               "envFrom": Array [

--- a/src/components/azure-pg/create-db.job.ts
+++ b/src/components/azure-pg/create-db.job.ts
@@ -3,7 +3,7 @@ import { Job } from "kubernetes-models/batch/v1/Job";
 
 //import { Params } from "../azure-db/params";
 
-const DEFAULT_EXTENSIONS = "hstore pgcrypto citext";
+const DEFAULT_EXTENSIONS = "hstore pgcrypto citext uuid-ossp";
 
 // needs azure-pg-admin-user secret
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types


### PR DESCRIPTION
This wont work directly : 

```
autodevops_495ad82f=> CREATE EXTENSION  uuid-ossp;
ERROR:  syntax error at or near "-"
LINE 1: CREATE EXTENSION  uuid-ossp;
                              ^
autodevops_495ad82f=> CREATE EXTENSION "uuid-ossp";
CREATE EXTENSION
autodevops_495ad82f=>
```