### PR TITLE
feat(azure-db): add config.prepareScript

### DIFF
--- a/e2e/templates/simple/kosko generate/__tests__/__snapshots__/--env dev.ts.snap
+++ b/e2e/templates/simple/kosko generate/__tests__/__snapshots__/--env dev.ts.snap
@@ -144,6 +144,158 @@ metadata:
     app.gitlab.com/env: e2e-branch-42
     app.gitlab.com/env.name: e2e-branch-dev2
   labels:
+    application: e2e-branch-42-sample-kosko
+    owner: sample-kosko
+    team: sample-kosko
+    cert: wildcard
+  name: create-db-job-8843083
+  namespace: sample-kosko-secret
+spec:
+  ttlSecondsAfterFinished: 86400
+  backoffLimit: 0
+  template:
+    spec:
+      containers:
+        - command:
+            - create-db-user
+          env:
+            - name: NEW_DB_NAME
+              value: autodevops_8843083
+            - name: NEW_USER
+              value: user_8843083
+            - name: NEW_PASSWORD
+              value: password_8843083
+            - name: NEW_DB_EXTENSIONS
+              value: hstore pgcrypto citext
+          envFrom:
+            - secretRef:
+                name: azure-pg-admin-user
+          image: >-
+            registry.gitlab.factory.social.gouv.fr/socialgouv/docker/azure-db:2.1.0
+          imagePullPolicy: IfNotPresent
+          name: create-db-user
+          resources:
+            limits:
+              cpu: 300m
+              memory: 256Mi
+            requests:
+              cpu: 100m
+              memory: 64Mi
+      restartPolicy: Never
+    metadata:
+      annotations:
+        app.gitlab.com/app: socialgouv-sample-kosko
+        app.gitlab.com/env: e2e-branch-42
+        app.gitlab.com/env.name: e2e-branch-dev2
+      labels:
+        application: e2e-branch-42-sample-kosko
+        owner: sample-kosko
+        team: sample-kosko
+        cert: wildcard
+apiVersion: batch/v1
+kind: Job
+---
+metadata:
+  annotations:
+    app.gitlab.com/app: socialgouv-sample-kosko
+    app.gitlab.com/env: e2e-branch-42
+    app.gitlab.com/env.name: e2e-branch-dev2
+  labels:
+    application: e2e-branch-42-sample-kosko
+    owner: sample-kosko
+    team: sample-kosko
+    cert: wildcard
+  name: prepare-db-job-8843083
+  namespace: sample-kosko-secret
+spec:
+  ttlSecondsAfterFinished: 86400
+  backoffLimit: 0
+  template:
+    spec:
+      containers:
+        - command:
+            - psql
+            - '--dbname'
+            - autodevops_8843083
+            - '-c'
+            - |-
+
+              ALTER USER user_8843083 with CREATEROLE;
+              GRANT anonymous TO user_8843083;
+                    
+          envFrom:
+            - secretRef:
+                name: azure-pg-admin-user
+          image: 'postgres:10'
+          imagePullPolicy: IfNotPresent
+          name: psql-job
+          resources:
+            limits:
+              cpu: 300m
+              memory: 256Mi
+            requests:
+              cpu: 100m
+              memory: 64Mi
+      restartPolicy: Never
+      initContainers:
+        - image: >-
+            registry.gitlab.factory.social.gouv.fr/socialgouv/docker/kubectl:2.2.0
+          name: init-prepare-db-8843083
+          command:
+            - kubectl
+            - wait
+            - '--namespace'
+            - sample-kosko-secret
+            - '--for=condition=complete'
+            - jobs/create-db-job-8843083
+    metadata:
+      annotations:
+        app.gitlab.com/app: socialgouv-sample-kosko
+        app.gitlab.com/env: e2e-branch-42
+        app.gitlab.com/env.name: e2e-branch-dev2
+      labels:
+        application: e2e-branch-42-sample-kosko
+        owner: sample-kosko
+        team: sample-kosko
+        cert: wildcard
+apiVersion: batch/v1
+kind: Job
+---
+metadata:
+  annotations:
+    app.gitlab.com/app: socialgouv-sample-kosko
+    app.gitlab.com/env: e2e-branch-42
+    app.gitlab.com/env.name: e2e-branch-dev2
+  labels:
+    application: e2e-branch-42-sample-kosko
+    owner: sample-kosko
+    team: sample-kosko
+    cert: wildcard
+  name: azure-pg-user-8843083
+  namespace: sample-kosko-24-e2e-branch-42
+stringData:
+  DATABASE_URL: >-
+    postgresql://user_8843083%40samplekoskodevserver.postgres.database.azure.com:password_8843083@samplekoskodevserver.postgres.database.azure.com/autodevops_8843083?sslmode=require
+  DB_URI: >-
+    postgresql://user_8843083%40samplekoskodevserver.postgres.database.azure.com:password_8843083@samplekoskodevserver.postgres.database.azure.com/autodevops_8843083?sslmode=require
+  HASURA_GRAPHQL_DATABASE_URL: >-
+    postgresql://user_8843083%40samplekoskodevserver.postgres.database.azure.com:password_8843083@samplekoskodevserver.postgres.database.azure.com/autodevops_8843083?sslmode=require
+  PGDATABASE: autodevops_8843083
+  PGHOST: samplekoskodevserver.postgres.database.azure.com
+  PGPASSWORD: password_8843083
+  PGRST_DB_URI: >-
+    postgresql://user_8843083%40samplekoskodevserver.postgres.database.azure.com:password_8843083@samplekoskodevserver.postgres.database.azure.com/autodevops_8843083?sslmode=require
+  PGSSLMODE: require
+  PGUSER: user_8843083@samplekoskodevserver.postgres.database.azure.com
+apiVersion: v1
+kind: Secret
+---
+metadata:
+  annotations:
+    app.gitlab.com/app: socialgouv-sample-kosko
+    app.gitlab.com/env: e2e-branch-42
+    app.gitlab.com/env.name: e2e-branch-dev2
+  labels:
     app: pgweb
     application: e2e-branch-42-sample-kosko
     owner: sample-kosko

--- a/e2e/templates/simple/kosko generate/__tests__/__snapshots__/--env dev.ts.snap
+++ b/e2e/templates/simple/kosko generate/__tests__/__snapshots__/--env dev.ts.snap
@@ -129,9 +129,9 @@ metadata:
   namespace: sample-kosko-24-e2e-branch-42
 spec:
   ports:
-    - port: 80
+    - name: http
+      port: 80
       targetPort: 80
-      name: http
   selector:
     app: hasura
   type: ClusterIP
@@ -151,7 +151,6 @@ metadata:
   name: create-db-job-8843083
   namespace: sample-kosko-secret
 spec:
-  ttlSecondsAfterFinished: 86400
   backoffLimit: 0
   template:
     spec:
@@ -192,6 +191,7 @@ spec:
         owner: sample-kosko
         team: sample-kosko
         cert: wildcard
+  ttlSecondsAfterFinished: 86400
 apiVersion: batch/v1
 kind: Job
 ---
@@ -208,7 +208,6 @@ metadata:
   name: prepare-db-job-8843083
   namespace: sample-kosko-secret
 spec:
-  ttlSecondsAfterFinished: 86400
   backoffLimit: 0
   template:
     spec:
@@ -238,16 +237,18 @@ spec:
               memory: 64Mi
       restartPolicy: Never
       initContainers:
-        - image: >-
-            registry.gitlab.factory.social.gouv.fr/socialgouv/docker/kubectl:2.2.0
-          name: init-prepare-db-8843083
-          command:
+        - command:
             - kubectl
             - wait
+            - '--timeout'
+            - '120'
             - '--namespace'
             - sample-kosko-secret
             - '--for=condition=complete'
             - jobs/create-db-job-8843083
+          image: >-
+            registry.gitlab.factory.social.gouv.fr/socialgouv/docker/kubectl:2.2.0
+          name: init-prepare-db-8843083
     metadata:
       annotations:
         app.gitlab.com/app: socialgouv-sample-kosko
@@ -258,6 +259,7 @@ spec:
         owner: sample-kosko
         team: sample-kosko
         cert: wildcard
+  ttlSecondsAfterFinished: 86400
 apiVersion: batch/v1
 kind: Job
 ---
@@ -396,9 +398,9 @@ metadata:
   namespace: sample-kosko-24-e2e-branch-42
 spec:
   ports:
-    - port: 80
+    - name: http
+      port: 80
       targetPort: 8081
-      name: http
   selector:
     app: pgweb
   type: ClusterIP
@@ -526,9 +528,9 @@ metadata:
   namespace: sample-kosko-24-e2e-branch-42
 spec:
   ports:
-    - port: 80
+    - name: http
+      port: 80
       targetPort: 6379
-      name: http
   selector:
     app: redis
   type: ClusterIP
@@ -646,9 +648,9 @@ metadata:
   namespace: sample-kosko-24-e2e-branch-42
 spec:
   ports:
-    - port: 80
+    - name: http
+      port: 80
       targetPort: 8080
-      name: http
   selector:
     app: www
   type: ClusterIP

--- a/e2e/templates/simple/kosko generate/__tests__/__snapshots__/--env preprod.ts.snap
+++ b/e2e/templates/simple/kosko generate/__tests__/__snapshots__/--env preprod.ts.snap
@@ -129,9 +129,9 @@ metadata:
   namespace: sample-next-app-24-preprod-dev2
 spec:
   ports:
-    - port: 80
+    - name: http
+      port: 80
       targetPort: 80
-      name: http
   selector:
     app: hasura
   type: ClusterIP
@@ -244,9 +244,9 @@ metadata:
   namespace: sample-next-app-24-preprod-dev2
 spec:
   ports:
-    - port: 80
+    - name: http
+      port: 80
       targetPort: 8081
-      name: http
   selector:
     app: pgweb
   type: ClusterIP
@@ -374,9 +374,9 @@ metadata:
   namespace: sample-next-app-24-preprod-dev2
 spec:
   ports:
-    - port: 80
+    - name: http
+      port: 80
       targetPort: 6379
-      name: http
   selector:
     app: redis
   type: ClusterIP
@@ -494,9 +494,9 @@ metadata:
   namespace: sample-next-app-24-preprod-dev2
 spec:
   ports:
-    - port: 80
+    - name: http
+      port: 80
       targetPort: 8080
-      name: http
   selector:
     app: www
   type: ClusterIP

--- a/e2e/templates/simple/kosko generate/__tests__/__snapshots__/--env prod.ts.snap
+++ b/e2e/templates/simple/kosko generate/__tests__/__snapshots__/--env prod.ts.snap
@@ -108,9 +108,9 @@ metadata:
   namespace: sample-kosko
 spec:
   ports:
-    - port: 80
+    - name: http
+      port: 80
       targetPort: 80
-      name: http
   selector:
     app: hasura
   type: ClusterIP
@@ -220,9 +220,9 @@ metadata:
   namespace: sample-kosko
 spec:
   ports:
-    - port: 80
+    - name: http
+      port: 80
       targetPort: 8081
-      name: http
   selector:
     app: pgweb
   type: ClusterIP
@@ -348,9 +348,9 @@ metadata:
   namespace: sample-kosko
 spec:
   ports:
-    - port: 80
+    - name: http
+      port: 80
       targetPort: 6379
-      name: http
   selector:
     app: redis
   type: ClusterIP
@@ -486,9 +486,9 @@ metadata:
   namespace: sample-kosko
 spec:
   ports:
-    - port: 80
+    - name: http
+      port: 80
       targetPort: 8080
-      name: http
   selector:
     app: www
   type: ClusterIP

--- a/src/components/azure-pg/__snapshots__/create-psql.test.ts.snap
+++ b/src/components/azure-pg/__snapshots__/create-psql.test.ts.snap
@@ -1,0 +1,97 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should create a psql job 1`] = `
+Object {
+  "apiVersion": "batch/v1",
+  "kind": "Job",
+  "metadata": Object {},
+  "spec": Object {
+    "backoffLimit": 0,
+    "template": Object {
+      "spec": Object {
+        "containers": Array [
+          Object {
+            "command": Array [
+              "psql",
+              "--dbname",
+              "some-db",
+              "-c",
+              "SELECT VERSION();",
+            ],
+            "envFrom": Array [
+              Object {
+                "secretRef": Object {
+                  "name": "some-secret",
+                },
+              },
+            ],
+            "image": "postgres:10",
+            "imagePullPolicy": "IfNotPresent",
+            "name": "psql-job",
+            "resources": Object {
+              "limits": Object {
+                "cpu": "300m",
+                "memory": "256Mi",
+              },
+              "requests": Object {
+                "cpu": "100m",
+                "memory": "64Mi",
+              },
+            },
+          },
+        ],
+        "restartPolicy": "Never",
+      },
+    },
+    "ttlSecondsAfterFinished": 86400,
+  },
+}
+`;
+
+exports[`should use admin secret as default 1`] = `
+Object {
+  "apiVersion": "batch/v1",
+  "kind": "Job",
+  "metadata": Object {},
+  "spec": Object {
+    "backoffLimit": 0,
+    "template": Object {
+      "spec": Object {
+        "containers": Array [
+          Object {
+            "command": Array [
+              "psql",
+              "--dbname",
+              "some-db2",
+              "-c",
+              "SELECT VERSION();",
+            ],
+            "envFrom": Array [
+              Object {
+                "secretRef": Object {
+                  "name": "azure-pg-admin-user",
+                },
+              },
+            ],
+            "image": "postgres:10",
+            "imagePullPolicy": "IfNotPresent",
+            "name": "psql-job",
+            "resources": Object {
+              "limits": Object {
+                "cpu": "300m",
+                "memory": "256Mi",
+              },
+              "requests": Object {
+                "cpu": "100m",
+                "memory": "64Mi",
+              },
+            },
+          },
+        ],
+        "restartPolicy": "Never",
+      },
+    },
+    "ttlSecondsAfterFinished": 86400,
+  },
+}
+`;

--- a/src/components/azure-pg/__snapshots__/index.test.ts.snap
+++ b/src/components/azure-pg/__snapshots__/index.test.ts.snap
@@ -1,5 +1,209 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`should add prepareDb job 1`] = `
+Array [
+  Object {
+    "apiVersion": "batch/v1",
+    "kind": "Job",
+    "metadata": Object {
+      "annotations": Object {
+        "app.gitlab.com/app": "socialgouv-sample",
+        "app.gitlab.com/env": "my-test",
+        "app.gitlab.com/env.name": "fabrique-dev",
+      },
+      "labels": Object {
+        "application": "my-test-sample",
+        "owner": "sample",
+        "team": "sample",
+      },
+      "name": "create-db-job-abcdefg",
+      "namespace": "sample-secret",
+    },
+    "spec": Object {
+      "backoffLimit": 0,
+      "template": Object {
+        "metadata": Object {
+          "annotations": Object {
+            "app.gitlab.com/app": "socialgouv-sample",
+            "app.gitlab.com/env": "my-test",
+            "app.gitlab.com/env.name": "fabrique-dev",
+          },
+          "labels": Object {
+            "application": "my-test-sample",
+            "owner": "sample",
+            "team": "sample",
+          },
+        },
+        "spec": Object {
+          "containers": Array [
+            Object {
+              "command": Array [
+                "create-db-user",
+              ],
+              "env": Array [
+                Object {
+                  "name": "NEW_DB_NAME",
+                  "value": "autodevops_abcdefg",
+                },
+                Object {
+                  "name": "NEW_USER",
+                  "value": "user_abcdefg",
+                },
+                Object {
+                  "name": "NEW_PASSWORD",
+                  "value": "password_abcdefg",
+                },
+                Object {
+                  "name": "NEW_DB_EXTENSIONS",
+                  "value": "hstore pgcrypto citext",
+                },
+              ],
+              "envFrom": Array [
+                Object {
+                  "secretRef": Object {
+                    "name": "azure-pg-admin-user",
+                  },
+                },
+              ],
+              "image": "registry.gitlab.factory.social.gouv.fr/socialgouv/docker/azure-db:2.1.0",
+              "imagePullPolicy": "IfNotPresent",
+              "name": "create-db-user",
+              "resources": Object {
+                "limits": Object {
+                  "cpu": "300m",
+                  "memory": "256Mi",
+                },
+                "requests": Object {
+                  "cpu": "100m",
+                  "memory": "64Mi",
+                },
+              },
+            },
+          ],
+          "restartPolicy": "Never",
+        },
+      },
+      "ttlSecondsAfterFinished": 86400,
+    },
+  },
+  Object {
+    "apiVersion": "batch/v1",
+    "kind": "Job",
+    "metadata": Object {
+      "annotations": Object {
+        "app.gitlab.com/app": "socialgouv-sample",
+        "app.gitlab.com/env": "my-test",
+        "app.gitlab.com/env.name": "fabrique-dev",
+      },
+      "labels": Object {
+        "application": "my-test-sample",
+        "owner": "sample",
+        "team": "sample",
+      },
+      "name": "prepare-db-job-abcdefg",
+      "namespace": "sample-secret",
+    },
+    "spec": Object {
+      "backoffLimit": 0,
+      "template": Object {
+        "metadata": Object {
+          "annotations": Object {
+            "app.gitlab.com/app": "socialgouv-sample",
+            "app.gitlab.com/env": "my-test",
+            "app.gitlab.com/env.name": "fabrique-dev",
+          },
+          "labels": Object {
+            "application": "my-test-sample",
+            "owner": "sample",
+            "team": "sample",
+          },
+        },
+        "spec": Object {
+          "containers": Array [
+            Object {
+              "command": Array [
+                "psql",
+                "--dbname",
+                "autodevops_abcdefg",
+                "-c",
+                "select VERSION();",
+              ],
+              "envFrom": Array [
+                Object {
+                  "secretRef": Object {
+                    "name": "azure-pg-admin-user",
+                  },
+                },
+              ],
+              "image": "postgres:10",
+              "imagePullPolicy": "IfNotPresent",
+              "name": "psql-job",
+              "resources": Object {
+                "limits": Object {
+                  "cpu": "300m",
+                  "memory": "256Mi",
+                },
+                "requests": Object {
+                  "cpu": "100m",
+                  "memory": "64Mi",
+                },
+              },
+            },
+          ],
+          "initContainers": Array [
+            Object {
+              "command": Array [
+                "kubectl",
+                "wait",
+                "--timeout",
+                "120",
+                "--namespace",
+                "sample-secret",
+                "--for=condition=complete",
+                "jobs/create-db-job-abcdefg",
+              ],
+              "image": "registry.gitlab.factory.social.gouv.fr/socialgouv/docker/kubectl:2.2.0",
+              "name": "init-prepare-db-abcdefg",
+            },
+          ],
+          "restartPolicy": "Never",
+        },
+      },
+      "ttlSecondsAfterFinished": 86400,
+    },
+  },
+  Object {
+    "apiVersion": "v1",
+    "kind": "Secret",
+    "metadata": Object {
+      "annotations": Object {
+        "app.gitlab.com/app": "socialgouv-sample",
+        "app.gitlab.com/env": "my-test",
+        "app.gitlab.com/env.name": "fabrique-dev",
+      },
+      "labels": Object {
+        "application": "my-test-sample",
+        "owner": "sample",
+        "team": "sample",
+      },
+      "name": "azure-pg-user-abcdefg",
+      "namespace": "sample-42-my-test",
+    },
+    "stringData": Object {
+      "DATABASE_URL": "postgresql://user_abcdefg%40sampledevserver.postgres.database.azure.com:password_abcdefg@sampledevserver.postgres.database.azure.com/autodevops_abcdefg?sslmode=require",
+      "DB_URI": "postgresql://user_abcdefg%40sampledevserver.postgres.database.azure.com:password_abcdefg@sampledevserver.postgres.database.azure.com/autodevops_abcdefg?sslmode=require",
+      "HASURA_GRAPHQL_DATABASE_URL": "postgresql://user_abcdefg%40sampledevserver.postgres.database.azure.com:password_abcdefg@sampledevserver.postgres.database.azure.com/autodevops_abcdefg?sslmode=require",
+      "PGDATABASE": "autodevops_abcdefg",
+      "PGHOST": "sampledevserver.postgres.database.azure.com",
+      "PGPASSWORD": "password_abcdefg",
+      "PGRST_DB_URI": "postgresql://user_abcdefg%40sampledevserver.postgres.database.azure.com:password_abcdefg@sampledevserver.postgres.database.azure.com/autodevops_abcdefg?sslmode=require",
+      "PGSSLMODE": "require",
+      "PGUSER": "user_abcdefg@sampledevserver.postgres.database.azure.com",
+    },
+  },
+]
+`;
+
 exports[`should return create an job 1`] = `
 Array [
   Object {

--- a/src/components/azure-pg/create-db.job.ts
+++ b/src/components/azure-pg/create-db.job.ts
@@ -22,7 +22,6 @@ export const createDbJob = ({
       //  ...metadataFromParams(params),
     },
     spec: {
-      ttlSecondsAfterFinished: 86400,
       backoffLimit: 0,
       template: {
         spec: {
@@ -73,6 +72,7 @@ export const createDbJob = ({
           restartPolicy: "Never",
         },
       },
+      ttlSecondsAfterFinished: 86400,
     },
   });
   return job;

--- a/src/components/azure-pg/create-db.test.ts
+++ b/src/components/azure-pg/create-db.test.ts
@@ -6,10 +6,10 @@ test("should customize secret and extensions when running create-db", () => {
   expect(
     createDbJob({
       database: "some-db",
-      user: "some-user",
+      extensions: "some-extension",
       password: "some-password",
       secretRefName: "some-secret",
-      extensions: "some-extension",
+      user: "some-user",
     })
   ).toMatchSnapshot();
 });
@@ -18,8 +18,8 @@ test("should use defaults when running create-db", () => {
   expect(
     createDbJob({
       database: "some-db",
-      user: "some-user",
       password: "some-password",
+      user: "some-user",
     })
   ).toMatchSnapshot();
 });

--- a/src/components/azure-pg/create-psql.job.ts
+++ b/src/components/azure-pg/create-psql.job.ts
@@ -1,11 +1,10 @@
 import { Job } from "kubernetes-models/batch/v1/Job";
-import { EnvVar } from "kubernetes-models/v1/EnvVar";
 
-type PsqlJobParams = {
+interface PsqlJobParams {
   secretRefName?: string;
   database: string;
   script: string;
-};
+}
 // needs azure-pg-admin-user secret
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export const createPsqlJob = ({
@@ -16,7 +15,6 @@ export const createPsqlJob = ({
   const job = new Job({
     metadata: {},
     spec: {
-      ttlSecondsAfterFinished: 86400,
       backoffLimit: 0,
       template: {
         spec: {
@@ -48,6 +46,7 @@ export const createPsqlJob = ({
           restartPolicy: "Never",
         },
       },
+      ttlSecondsAfterFinished: 86400,
     },
   });
   return job;

--- a/src/components/azure-pg/create-psql.job.ts
+++ b/src/components/azure-pg/create-psql.job.ts
@@ -1,0 +1,50 @@
+import { Job } from "kubernetes-models/batch/v1/Job";
+
+// needs azure-pg-admin-user secret
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+export const createPsqlJob = ({
+  //@ts-expect-error
+  script,
+  //@ts-expect-error
+  database,
+  secretRefName = `azure-pg-admin-user`,
+}): Job => {
+  const job = new Job({
+    metadata: {},
+    spec: {
+      ttlSecondsAfterFinished: 86400,
+      backoffLimit: 0,
+      template: {
+        spec: {
+          containers: [
+            {
+              command: ["psql", "--dbname", database, "-c", script],
+              envFrom: [
+                {
+                  secretRef: {
+                    name: secretRefName,
+                  },
+                },
+              ],
+              image: "postgres:10",
+              imagePullPolicy: "IfNotPresent",
+              name: "psql-job",
+              resources: {
+                limits: {
+                  cpu: "300m",
+                  memory: "256Mi",
+                },
+                requests: {
+                  cpu: "100m",
+                  memory: "64Mi",
+                },
+              },
+            },
+          ],
+          restartPolicy: "Never",
+        },
+      },
+    },
+  });
+  return job;
+};

--- a/src/components/azure-pg/create-psql.job.ts
+++ b/src/components/azure-pg/create-psql.job.ts
@@ -1,14 +1,18 @@
 import { Job } from "kubernetes-models/batch/v1/Job";
+import { EnvVar } from "kubernetes-models/v1/EnvVar";
 
+type PsqlJobParams = {
+  secretRefName?: string;
+  database: string;
+  script: string;
+};
 // needs azure-pg-admin-user secret
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export const createPsqlJob = ({
-  //@ts-expect-error
   script,
-  //@ts-expect-error
   database,
   secretRefName = `azure-pg-admin-user`,
-}): Job => {
+}: PsqlJobParams): Job => {
   const job = new Job({
     metadata: {},
     spec: {

--- a/src/components/azure-pg/create-psql.test.ts
+++ b/src/components/azure-pg/create-psql.test.ts
@@ -1,0 +1,22 @@
+import { createPsqlJob } from "./create-psql.job";
+
+process.env.CI_COMMIT_SHORT_SHA = "b123a99";
+
+test("should create a psql job", () => {
+  expect(
+    createPsqlJob({
+      database: "some-db",
+      script: "SELECT VERSION();",
+      secretRefName: "some-secret",
+    })
+  ).toMatchSnapshot();
+});
+
+test("should use admin secret as default", () => {
+  expect(
+    createPsqlJob({
+      database: "some-db2",
+      script: "SELECT VERSION();",
+    })
+  ).toMatchSnapshot();
+});

--- a/src/components/azure-pg/drop-db.test.ts
+++ b/src/components/azure-pg/drop-db.test.ts
@@ -6,8 +6,8 @@ test("should customize secret and extensions when running drop-db", () => {
   expect(
     dropDbJob({
       database: "some-db",
-      user: "some-user",
       secretRefName: "some-secret",
+      user: "some-user",
     })
   ).toMatchSnapshot();
 });

--- a/src/components/azure-pg/index.test.ts
+++ b/src/components/azure-pg/index.test.ts
@@ -56,7 +56,7 @@ test("should use custom pgHost", async () => {
   ).toMatchSnapshot();
 });
 
-test("should add prepareDb job", async () => {
+test("should add prepareDb job", () => {
   Object.assign(process.env, gitlabEnv);
   const cwd = directory();
   const env = new Environment(cwd);

--- a/src/components/azure-pg/index.test.ts
+++ b/src/components/azure-pg/index.test.ts
@@ -55,3 +55,13 @@ test("should use custom pgHost", async () => {
     create({ env, config: { pgHost: "pouetpouet.com" } })
   ).toMatchSnapshot();
 });
+
+test("should add prepareDb job", async () => {
+  Object.assign(process.env, gitlabEnv);
+  const cwd = directory();
+  const env = new Environment(cwd);
+  env.env = "dev";
+  expect(
+    create({ env, config: { prepareScript: "select VERSION();" } })
+  ).toMatchSnapshot();
+});

--- a/src/components/azure-pg/index.ts
+++ b/src/components/azure-pg/index.ts
@@ -55,11 +55,11 @@ interface CreateParams {
   config?: Partial<CreateConfig>;
 }
 
-type WaitForJobInitContainer = {
+interface WaitForJobInitContainer {
   name: string;
   namespace: string;
   jobId: string;
-};
+}
 
 const waitForJobInitContainer = ({
   name,

--- a/src/components/azure-pg/index.ts
+++ b/src/components/azure-pg/index.ts
@@ -5,10 +5,13 @@ import { ok } from "assert";
 import { DeploymentParams } from "../../utils/createDeployment";
 import { getPgServerHostname } from "../../utils/getPgServerHostname";
 import { updateMetadata } from "../../utils/updateMetadata";
+import { addInitContainer } from "../../utils/addInitContainer";
+import { waitForPostgres } from "../../utils/waitForPostgres";
 import { createSecret } from "../pg-secret/create";
 import { createDbJob } from "./create-db.job";
 import { createPsqlJob } from "./create-psql.job";
 import { getDevDatabaseParameters } from "./params";
+import { EnvVar } from "kubernetes-models/v1/EnvVar";
 
 interface PgParams {
   database: string;
@@ -54,8 +57,12 @@ interface CreateParams {
   config?: Partial<CreateConfig>;
 }
 
+import { IoK8sApiCoreV1Container } from "kubernetes-models/_definitions/IoK8sApiCoreV1Container";
+
 export const create = ({ config = {} }: CreateParams): unknown[] => {
   const defaultParams = getDefaultPgParams(config);
+
+  const manifests = [];
 
   // kosko component env values
   const envParams = {
@@ -66,27 +73,54 @@ export const create = ({ config = {} }: CreateParams): unknown[] => {
 
   const secretNamespace = { name: `${process.env.CI_PROJECT_NAME}-secret` };
 
-  const job = createDbJob(defaultParams);
-  updateMetadata(job, {
+  const createJob = createDbJob(defaultParams);
+  updateMetadata(createJob, {
     annotations: envParams.annotations ?? {},
     labels: envParams.labels ?? {},
     name: `create-db-job-${process.env.CI_COMMIT_SHORT_SHA}`,
     namespace: secretNamespace,
   });
+  manifests.push(createJob);
 
+  // create a new job in the app-secret namespace with full rights on the DB
   if (config.prepareScript) {
-    const job = createPsqlJob({
+    const prepareJob = createPsqlJob({
       database: `autodevops_${process.env.CI_COMMIT_SHORT_SHA}`,
       script: config.prepareScript,
     });
-    updateMetadata(job, {
+
+    // add an initContainer to wait for the create-db job to be complete
+    const initContainer = new IoK8sApiCoreV1Container({
+      image:
+        "registry.gitlab.factory.social.gouv.fr/socialgouv/docker/kubectl:2.2.0",
+      name: `init-prepare-db-${process.env.CI_COMMIT_SHORT_SHA}`,
+      command: [
+        "kubectl",
+        "wait",
+        "--timeout",
+        "120",
+        "--namespace",
+        secretNamespace.name,
+        "--for=condition=complete",
+        `jobs/create-db-job-${process.env.CI_COMMIT_SHORT_SHA}`,
+      ],
+    });
+
+    ok(prepareJob.spec);
+    ok(prepareJob.spec.template.spec);
+    prepareJob.spec.template.spec.initContainers = [initContainer];
+
+    updateMetadata(prepareJob, {
       annotations: envParams.annotations ?? {},
       labels: envParams.labels ?? {},
       name: `prepare-db-job-${process.env.CI_COMMIT_SHORT_SHA}`,
       namespace: secretNamespace,
     });
+
+    manifests.push(prepareJob);
   }
 
+  // create a PG user secret in branch namespace
   const secret = createSecret(envParams);
   updateMetadata(secret, {
     annotations: envParams.annotations ?? {},
@@ -94,5 +128,7 @@ export const create = ({ config = {} }: CreateParams): unknown[] => {
     name: defaultParams.name,
     namespace: envParams.namespace,
   });
-  return [job, secret];
+  manifests.push(secret);
+
+  return manifests;
 };

--- a/src/utils/createService.ts
+++ b/src/utils/createService.ts
@@ -25,9 +25,9 @@ export default (params: Params): Service => {
     spec: {
       ports: [
         {
+          name: params.portName ?? "http",
           port: params.servicePort,
           targetPort: params.containerPort,
-          name: params.portName ?? "http",
         },
       ],
       selector: params.selector,

--- a/templates/simple/components/pg.ts
+++ b/templates/simple/components/pg.ts
@@ -1,0 +1,25 @@
+import env from "@kosko/env";
+import { SealedSecret } from "@kubernetes-models/sealed-secrets/bitnami.com/v1alpha1/SealedSecret";
+
+import { loadYaml } from "@socialgouv/kosko-charts/utils/getEnvironmentComponent";
+import { updateMetadata } from "@socialgouv/kosko-charts/utils/updateMetadata";
+import gitlab from "@socialgouv/kosko-charts/environments/gitlab";
+
+import { create } from "@socialgouv/kosko-charts/components/azure-pg";
+
+export default () => {
+  if (env.env === "dev" || env.env === "local") {
+    return create({
+      env,
+      config: {
+        // custom script on create db
+        prepareScript: `
+ALTER USER user_${process.env.CI_COMMIT_SHORT_SHA} with CREATEROLE;
+GRANT anonymous TO user_${process.env.CI_COMMIT_SHORT_SHA};
+      `,
+      },
+    });
+  }
+
+  return [];
+};

--- a/templates/simple/components/pg.ts
+++ b/templates/simple/components/pg.ts
@@ -1,16 +1,9 @@
 import env from "@kosko/env";
-import { SealedSecret } from "@kubernetes-models/sealed-secrets/bitnami.com/v1alpha1/SealedSecret";
-
-import { loadYaml } from "@socialgouv/kosko-charts/utils/getEnvironmentComponent";
-import { updateMetadata } from "@socialgouv/kosko-charts/utils/updateMetadata";
-import gitlab from "@socialgouv/kosko-charts/environments/gitlab";
-
 import { create } from "@socialgouv/kosko-charts/components/azure-pg";
 
 export default () => {
   if (env.env === "dev" || env.env === "local") {
     return create({
-      env,
       config: {
         // custom script on create db
         prepareScript: `
@@ -18,6 +11,7 @@ ALTER USER user_${process.env.CI_COMMIT_SHORT_SHA} with CREATEROLE;
 GRANT anonymous TO user_${process.env.CI_COMMIT_SHORT_SHA};
       `,
       },
+      env,
     });
   }
 


### PR DESCRIPTION
In some cases, creating the db and user is not enough, some additionnal commands must be executed on the DB as a adminuser. ex: `GRANT anonymous TO user_d16bc2cf;`

the `azure-pg/config.prepareScript` allows to specify additionnal command to run after the DB creation as an admin user

it has an initcontainer that wait for the create-job to end before starting