### PR TITLE
revert(gitlab): remove -dev2 suffix on application name

### DIFF
--- a/e2e/testing/__fixtures__/__tests__/__snapshots__/kosko generate --env dev.ts.snap
+++ b/e2e/testing/__fixtures__/__tests__/__snapshots__/kosko generate --env dev.ts.snap
@@ -14,7 +14,7 @@ metadata:
     app.gitlab.com/env.name: master-dev2
   labels:
     azure-pg-admin-user: sample-nxt-app
-    application: master-sample-nxt-app
+    application: master-dev2-sample-nxt-app
     owner: sample-nxt-app
     team: sample-nxt-app
     cert: wildcard
@@ -32,7 +32,7 @@ metadata:
     app.gitlab.com/env.name: master-dev2
   labels:
     app: www
-    application: master-sample-nxt-app
+    application: master-dev2-sample-nxt-app
     owner: sample-nxt-app
     team: sample-nxt-app
     cert: wildcard
@@ -52,7 +52,7 @@ spec:
         app.gitlab.com/env.name: master-dev2
       labels:
         app: www
-        application: master-sample-nxt-app
+        application: master-dev2-sample-nxt-app
         owner: sample-nxt-app
         team: sample-nxt-app
         cert: wildcard
@@ -100,7 +100,7 @@ kind: Deployment
 metadata:
   labels:
     app: www
-    application: master-sample-nxt-app
+    application: master-dev2-sample-nxt-app
     owner: sample-nxt-app
     team: sample-nxt-app
     cert: wildcard
@@ -129,7 +129,7 @@ metadata:
     app.gitlab.com/env.name: master-dev2
   labels:
     app: www
-    application: master-sample-nxt-app
+    application: master-dev2-sample-nxt-app
     owner: sample-nxt-app
     team: sample-nxt-app
     cert: wildcard
@@ -137,7 +137,7 @@ metadata:
   namespace: sample-nxt-app-85-master-dev2
 spec:
   rules:
-    - host: master-sample-nxt-app.dev2.fabrique.social.gouv.fr
+    - host: master-dev2-sample-nxt-app.dev2.fabrique.social.gouv.fr
       http:
         paths:
           - backend:
@@ -146,7 +146,7 @@ spec:
             path: /
   tls:
     - hosts:
-        - master-sample-nxt-app.dev2.fabrique.social.gouv.fr
+        - master-dev2-sample-nxt-app.dev2.fabrique.social.gouv.fr
       secretName: wildcard-crt
 apiVersion: extensions/v1beta1
 kind: Ingress

--- a/src/environments/gitlab/index.ts
+++ b/src/environments/gitlab/index.ts
@@ -37,7 +37,7 @@ export default (env = process.env): GlobalEnvironment => {
     ? CI_PROJECT_NAME
     : CI_COMMIT_TAG
     ? `${CI_COMMIT_TAG.replace(/\./g, "-")}-${CI_PROJECT_NAME}`
-    : `${CI_ENVIRONMENT_SLUG.replace("-dev2", "")}-${CI_PROJECT_NAME}`;
+    : `${CI_ENVIRONMENT_SLUG}-${CI_PROJECT_NAME}`;
 
   const subdomain = isProductionCluster
     ? CI_PROJECT_NAME


### PR DESCRIPTION
This reverts commit 5e99bb056c50288bfac3ab2edeb17db21e7650cb.

restore review environments urls as [in autodevops](https://github.com/SocialGouv/gitlab-ci-yml/blob/master/base_autodevops.yml#L254)