### PR TITLE
feat: add utils.getHarborImagePath

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -57,6 +57,7 @@ See [kosko documentation](https://kosko.dev/docs/) for more usage examples
 - [[createIngress]]
 - [[createService]]
 - [[getDeployment]]
+- [[getHarborImagePath]]
 - [[getIngressHost]]
 - [[getManifestByKind]]
 - [[getPgServerHostname]]

--- a/src/utils/getHarborImagePath.test.ts
+++ b/src/utils/getHarborImagePath.test.ts
@@ -1,0 +1,50 @@
+import { getHarborImagePath } from "./getHarborImagePath";
+
+beforeEach(() => {
+  process.env.HARBOR_PREGISTRY = "default-registry";
+  process.env.HARBOR_PROJECT = "default-project";
+  process.env.CI_COMMIT_SHA = "2780ce341781678fe1f460742e87312fbabd827f";
+});
+
+test("default harbor path with commit sha", () => {
+  expect(getHarborImagePath({ name: "frontend" })).toStrictEqual(
+    "harbor.fabrique.social.gouv.fr/default-project/frontend:2780ce341781678fe1f460742e87312fbabd827f"
+  );
+});
+
+test("custom harbor projet with env var with commit sha", () => {
+  process.env.HARBOR_PROJECT = "some-project";
+  expect(getHarborImagePath({ name: "frontend" })).toStrictEqual(
+    "harbor.fabrique.social.gouv.fr/some-project/frontend:2780ce341781678fe1f460742e87312fbabd827f"
+  );
+});
+
+test("custom harbor project with param with commit sha", () => {
+  process.env.HARBOR_PROJECT = "some-project";
+  expect(
+    getHarborImagePath({ name: "frontend", project: "yet-another-project" })
+  ).toStrictEqual(
+    "harbor.fabrique.social.gouv.fr/yet-another-project/frontend:2780ce341781678fe1f460742e87312fbabd827f"
+  );
+});
+
+test("custom params with commit sha", () => {
+  expect(
+    getHarborImagePath({
+      name: "frontend",
+      project: "awesome-project",
+      registry: "my-registry",
+    })
+  ).toStrictEqual(
+    "my-registry/awesome-project/frontend:2780ce341781678fe1f460742e87312fbabd827f"
+  );
+});
+
+test("custom registry with tag", () => {
+  process.env.HARBOR_PROJECT = "another-project";
+  process.env.HARBOR_REGISTRY = "another-registry";
+  process.env.CI_COMMIT_TAG = "v1.2.3";
+  expect(getHarborImagePath({ name: "frontend" })).toStrictEqual(
+    "another-registry/another-project/frontend:1.2.3"
+  );
+});

--- a/src/utils/getHarborImagePath.ts
+++ b/src/utils/getHarborImagePath.ts
@@ -1,0 +1,38 @@
+/** Parameters to get a valid `registry/project/image:tag` harbor path */
+export interface HarborProjectImageProps {
+  /** name of the docker image */
+  name: string;
+  /** name of the harbor project */
+  project?: string;
+  /** registry if not `harbor.fabrique.social.gouv.fr` */
+  registry?: string;
+}
+
+/**
+ *
+ * This function will return the full path for a given docker image based on `CI_COMMIT_TAG` or `CI_COMMIT_SHA`
+ *
+ * ```typescript
+ * import { getHarborImagePath } from "@socialgouv/kosko-charts/utils"
+ *
+ * const imagePath = getHarborImagePath({
+ *   name: "docker-mario",
+ *   project: "sre", // defaults to process.env.HARBOR_PROJECT
+ *   registry: "chips.registry.com", // defaults to process.env.HARBOR_REGISTRY
+ * })
+ *
+ * ```
+ * @category utils
+ * @return {string}
+ */
+export const getHarborImagePath = ({
+  name,
+  registry = process.env.HARBOR_REGISTRY ?? "harbor.fabrique.social.gouv.fr",
+  project = process.env.HARBOR_PROJECT,
+}: HarborProjectImageProps): string => {
+  const tag = process.env.CI_COMMIT_TAG
+    ? process.env.CI_COMMIT_TAG.slice(1)
+    : process.env.CI_COMMIT_SHA;
+
+  return `${registry}/${project}/${name}:${tag}`;
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -10,6 +10,7 @@ export * from "./createDeployment";
 export * from "./createIngress";
 export * from "./createService";
 export * from "./getDeployment";
+export * from "./getHarborImagePath";
 export * from "./getIngressHost";
 export * from "./getManifestByKind";
 export * from "./getPgServerHostname";


### PR DESCRIPTION
add an utility to build the harbor registry image path during migration