### PR TITLE
fix(restore): enable multiple calls to job

### DIFF
--- a/src/components/azure-pg/__snapshots__/restore-db.job.test.ts.snap
+++ b/src/components/azure-pg/__snapshots__/restore-db.job.test.ts.snap
@@ -6,7 +6,7 @@ Array [
     "apiVersion": "batch/v1",
     "kind": "Job",
     "metadata": Object {
-      "name": "restore-db-b123a99",
+      "name": "restore-db-123456789",
       "namespace": "sample-next-app-secret",
     },
     "spec": Object {
@@ -161,7 +161,7 @@ Array [
     "apiVersion": "batch/v1",
     "kind": "Job",
     "metadata": Object {
-      "name": "restore-db-b123a99",
+      "name": "restore-db-123456789",
       "namespace": "sample-next-app-secret",
     },
     "spec": Object {

--- a/src/components/azure-pg/restore-db.job.test.ts
+++ b/src/components/azure-pg/restore-db.job.test.ts
@@ -4,6 +4,7 @@ import { restoreDbJob } from "./restore-db.job";
 
 process.env.CI_COMMIT_SHORT_SHA = "b123a99";
 process.env.CI_PROJECT_NAME = "some-app";
+process.env.CI_JOB_ID = "123456789";
 
 test("should create restore DB job", () => {
   expect(

--- a/src/components/azure-pg/restore-db.job.ts
+++ b/src/components/azure-pg/restore-db.job.ts
@@ -145,7 +145,7 @@ export const restoreDbJob = ({
 
   const job = new Job({
     metadata: {
-      name: `restore-db-${process.env.CI_COMMIT_SHORT_SHA}`,
+      name: `restore-db-${process.env.CI_JOB_ID}`,
       namespace: secretNamespace,
     },
     spec: {


### PR DESCRIPTION
use `CI_JOB_ID` instead of `CI_COMMIT_SHA` for the restore db job so we can run it multiple times if necessary