### PR TITLE
WIP: feat: db per branch

### DIFF
--- a/e2e/kitchen-sink/__tests__/__snapshots__/multihost.ts.snap
+++ b/e2e/kitchen-sink/__tests__/__snapshots__/multihost.ts.snap
@@ -97,7 +97,7 @@ spec:
             periodSeconds: 5
           envFrom:
             - secretRef:
-                name: azure-pg-user-8843083
+                name: azure-pg-user-e2e-branch
       imagePullSecrets:
         - name: regcred
       initContainers:
@@ -106,9 +106,9 @@ spec:
               value: '24'
           envFrom:
             - secretRef:
-                name: azure-pg-user-8843083
+                name: azure-pg-user-e2e-branch
           image: >-
-            registry.gitlab.factory.social.gouv.fr/socialgouv/docker/wait-for-postgres:4.6.0
+            registry.gitlab.factory.social.gouv.fr/socialgouv/docker/wait-for-postgres:4.3.1
           imagePullPolicy: Always
           name: wait-for-postgres
           resources:
@@ -223,7 +223,7 @@ spec:
             periodSeconds: 5
           envFrom:
             - secretRef:
-                name: azure-pg-user-8843083
+                name: azure-pg-user-e2e-branch
       imagePullSecrets:
         - name: some-secret
       initContainers:
@@ -232,9 +232,9 @@ spec:
               value: '24'
           envFrom:
             - secretRef:
-                name: azure-pg-user-8843083
+                name: azure-pg-user-e2e-branch
           image: >-
-            registry.gitlab.factory.social.gouv.fr/socialgouv/docker/wait-for-postgres:4.6.0
+            registry.gitlab.factory.social.gouv.fr/socialgouv/docker/wait-for-postgres:4.3.1
           imagePullPolicy: Always
           name: wait-for-postgres
           resources:

--- a/e2e/kitchen-sink/__tests__/__snapshots__/multihost.ts.snap
+++ b/e2e/kitchen-sink/__tests__/__snapshots__/multihost.ts.snap
@@ -108,7 +108,7 @@ spec:
             - secretRef:
                 name: azure-pg-user-e2e-branch
           image: >-
-            registry.gitlab.factory.social.gouv.fr/socialgouv/docker/wait-for-postgres:4.3.1
+            registry.gitlab.factory.social.gouv.fr/socialgouv/docker/wait-for-postgres:4.7.1
           imagePullPolicy: Always
           name: wait-for-postgres
           resources:
@@ -234,7 +234,7 @@ spec:
             - secretRef:
                 name: azure-pg-user-e2e-branch
           image: >-
-            registry.gitlab.factory.social.gouv.fr/socialgouv/docker/wait-for-postgres:4.3.1
+            registry.gitlab.factory.social.gouv.fr/socialgouv/docker/wait-for-postgres:4.7.1
           imagePullPolicy: Always
           name: wait-for-postgres
           resources:

--- a/e2e/kitchen-sink/environments/.gitlab-ci.env
+++ b/e2e/kitchen-sink/environments/.gitlab-ci.env
@@ -2,6 +2,7 @@
 # This is a snapshot of the GitLab env from the SocialGouv/sample-kosko
 #
 CI_COMMIT_REF_NAME=e2e-branch
+CI_COMMIT_REF_SLUG=e2e-branch
 CI_ENVIRONMENT_NAME=e2e-branch-dev2
 CI_ENVIRONMENT_SLUG=e2e-branch-42
 CI_ENVIRONMENT_URL=https://e2e-branch-dev2-sample-kosko.dev2.fabrique.social.gouv.fr

--- a/e2e/templates/hasura/kosko generate/__tests__/__snapshots__/--env dev.ts.snap
+++ b/e2e/templates/hasura/kosko generate/__tests__/__snapshots__/--env dev.ts.snap
@@ -96,7 +96,7 @@ spec:
             periodSeconds: 5
           envFrom:
             - secretRef:
-                name: azure-pg-user-8843083
+                name: azure-pg-user-e2e-branch
             - configMapRef:
                 name: hasura-configmap
       initContainers:
@@ -105,9 +105,9 @@ spec:
               value: '24'
           envFrom:
             - secretRef:
-                name: azure-pg-user-8843083
+                name: azure-pg-user-e2e-branch
           image: >-
-            registry.gitlab.factory.social.gouv.fr/socialgouv/docker/wait-for-postgres:4.6.0
+            registry.gitlab.factory.social.gouv.fr/socialgouv/docker/wait-for-postgres:4.3.1
           imagePullPolicy: Always
           name: wait-for-postgres
           resources:
@@ -210,11 +210,11 @@ spec:
             - create-db-user
           env:
             - name: NEW_DB_NAME
-              value: autodevops_8843083
+              value: autodevops_e2e-branch
             - name: NEW_USER
-              value: user_8843083
+              value: user_e2e-branch
             - name: NEW_PASSWORD
-              value: password_8843083
+              value: password_e2e-branch
             - name: NEW_DB_EXTENSIONS
               value: hstore pgcrypto citext uuid-ossp
           envFrom:
@@ -253,25 +253,25 @@ metadata:
     owner: sample-next-app
     team: sample-next-app
     cert: wildcard
-  name: create-db-job-8843083
+  name: create-db-job-e2e-branch
   namespace: sample-next-app-24-e2e-branch-42
 ---
 apiVersion: v1
 kind: Secret
 stringData:
   DATABASE_URL: >-
-    postgresql://user_8843083%40samplenextappdevserver.postgres.database.azure.com:password_8843083@samplenextappdevserver.postgres.database.azure.com/autodevops_8843083?sslmode=require
+    postgresql://user_e2e-branch%40samplenextappdevserver.postgres.database.azure.com:password_e2e-branch@samplenextappdevserver.postgres.database.azure.com/autodevops_e2e-branch?sslmode=require
   DB_URI: >-
-    postgresql://user_8843083%40samplenextappdevserver.postgres.database.azure.com:password_8843083@samplenextappdevserver.postgres.database.azure.com/autodevops_8843083?sslmode=require
+    postgresql://user_e2e-branch%40samplenextappdevserver.postgres.database.azure.com:password_e2e-branch@samplenextappdevserver.postgres.database.azure.com/autodevops_e2e-branch?sslmode=require
   HASURA_GRAPHQL_DATABASE_URL: >-
-    postgresql://user_8843083%40samplenextappdevserver.postgres.database.azure.com:password_8843083@samplenextappdevserver.postgres.database.azure.com/autodevops_8843083?sslmode=require
-  PGDATABASE: autodevops_8843083
+    postgresql://user_e2e-branch%40samplenextappdevserver.postgres.database.azure.com:password_e2e-branch@samplenextappdevserver.postgres.database.azure.com/autodevops_e2e-branch?sslmode=require
+  PGDATABASE: autodevops_e2e-branch
   PGHOST: samplenextappdevserver.postgres.database.azure.com
-  PGPASSWORD: password_8843083
+  PGPASSWORD: password_e2e-branch
   PGRST_DB_URI: >-
-    postgresql://user_8843083%40samplenextappdevserver.postgres.database.azure.com:password_8843083@samplenextappdevserver.postgres.database.azure.com/autodevops_8843083?sslmode=require
+    postgresql://user_e2e-branch%40samplenextappdevserver.postgres.database.azure.com:password_e2e-branch@samplenextappdevserver.postgres.database.azure.com/autodevops_e2e-branch?sslmode=require
   PGSSLMODE: require
-  PGUSER: user_8843083@samplenextappdevserver.postgres.database.azure.com
+  PGUSER: user_e2e-branch@samplenextappdevserver.postgres.database.azure.com
 metadata:
   annotations:
     app.gitlab.com/app: socialgouv-sample-next-app
@@ -282,6 +282,6 @@ metadata:
     owner: sample-next-app
     team: sample-next-app
     cert: wildcard
-  name: azure-pg-user-8843083
+  name: azure-pg-user-e2e-branch
   namespace: sample-next-app-24-e2e-branch-42"
 `;

--- a/e2e/templates/hasura/kosko generate/__tests__/__snapshots__/--env dev.ts.snap
+++ b/e2e/templates/hasura/kosko generate/__tests__/__snapshots__/--env dev.ts.snap
@@ -107,7 +107,7 @@ spec:
             - secretRef:
                 name: azure-pg-user-e2e-branch
           image: >-
-            registry.gitlab.factory.social.gouv.fr/socialgouv/docker/wait-for-postgres:4.3.1
+            registry.gitlab.factory.social.gouv.fr/socialgouv/docker/wait-for-postgres:4.7.1
           imagePullPolicy: Always
           name: wait-for-postgres
           resources:

--- a/e2e/templates/hasura/kosko generate/__tests__/__snapshots__/--env preprod.ts.snap
+++ b/e2e/templates/hasura/kosko generate/__tests__/__snapshots__/--env preprod.ts.snap
@@ -107,7 +107,7 @@ spec:
             - secretRef:
                 name: azure-pg-user
           image: >-
-            registry.gitlab.factory.social.gouv.fr/socialgouv/docker/wait-for-postgres:4.6.0
+            registry.gitlab.factory.social.gouv.fr/socialgouv/docker/wait-for-postgres:4.3.1
           imagePullPolicy: Always
           name: wait-for-postgres
           resources:

--- a/e2e/templates/hasura/kosko generate/__tests__/__snapshots__/--env preprod.ts.snap
+++ b/e2e/templates/hasura/kosko generate/__tests__/__snapshots__/--env preprod.ts.snap
@@ -107,7 +107,7 @@ spec:
             - secretRef:
                 name: azure-pg-user
           image: >-
-            registry.gitlab.factory.social.gouv.fr/socialgouv/docker/wait-for-postgres:4.3.1
+            registry.gitlab.factory.social.gouv.fr/socialgouv/docker/wait-for-postgres:4.7.1
           imagePullPolicy: Always
           name: wait-for-postgres
           resources:

--- a/e2e/templates/hasura/kosko generate/__tests__/__snapshots__/--env prod.ts.snap
+++ b/e2e/templates/hasura/kosko generate/__tests__/__snapshots__/--env prod.ts.snap
@@ -86,7 +86,7 @@ spec:
             - secretRef:
                 name: azure-pg-user
           image: >-
-            registry.gitlab.factory.social.gouv.fr/socialgouv/docker/wait-for-postgres:4.3.1
+            registry.gitlab.factory.social.gouv.fr/socialgouv/docker/wait-for-postgres:4.7.1
           imagePullPolicy: Always
           name: wait-for-postgres
           resources:

--- a/e2e/templates/hasura/kosko generate/__tests__/__snapshots__/--env prod.ts.snap
+++ b/e2e/templates/hasura/kosko generate/__tests__/__snapshots__/--env prod.ts.snap
@@ -86,7 +86,7 @@ spec:
             - secretRef:
                 name: azure-pg-user
           image: >-
-            registry.gitlab.factory.social.gouv.fr/socialgouv/docker/wait-for-postgres:4.6.0
+            registry.gitlab.factory.social.gouv.fr/socialgouv/docker/wait-for-postgres:4.3.1
           imagePullPolicy: Always
           name: wait-for-postgres
           resources:

--- a/e2e/templates/pgweb/kosko generate/__tests__/__snapshots__/--env dev.ts.snap
+++ b/e2e/templates/pgweb/kosko generate/__tests__/__snapshots__/--env dev.ts.snap
@@ -98,16 +98,16 @@ spec:
             periodSeconds: 5
           envFrom:
             - secretRef:
-                name: azure-pg-user-8843083
+                name: azure-pg-user-e2e-branch
       initContainers:
         - env:
             - name: WAIT_FOR_RETRIES
               value: '24'
           envFrom:
             - secretRef:
-                name: azure-pg-user-8843083
+                name: azure-pg-user-e2e-branch
           image: >-
-            registry.gitlab.factory.social.gouv.fr/socialgouv/docker/wait-for-postgres:4.6.0
+            registry.gitlab.factory.social.gouv.fr/socialgouv/docker/wait-for-postgres:4.3.1
           imagePullPolicy: Always
           name: wait-for-postgres
           resources:
@@ -187,11 +187,11 @@ spec:
             - create-db-user
           env:
             - name: NEW_DB_NAME
-              value: autodevops_8843083
+              value: autodevops_e2e-branch
             - name: NEW_USER
-              value: user_8843083
+              value: user_e2e-branch
             - name: NEW_PASSWORD
-              value: password_8843083
+              value: password_e2e-branch
             - name: NEW_DB_EXTENSIONS
               value: hstore pgcrypto citext uuid-ossp
           envFrom:
@@ -230,25 +230,25 @@ metadata:
     owner: sample-next-app
     team: sample-next-app
     cert: wildcard
-  name: create-db-job-8843083
+  name: create-db-job-e2e-branch
   namespace: sample-next-app-24-e2e-branch-42
 ---
 apiVersion: v1
 kind: Secret
 stringData:
   DATABASE_URL: >-
-    postgresql://user_8843083%40samplenextappdevserver.postgres.database.azure.com:password_8843083@samplenextappdevserver.postgres.database.azure.com/autodevops_8843083?sslmode=require
+    postgresql://user_e2e-branch%40samplenextappdevserver.postgres.database.azure.com:password_e2e-branch@samplenextappdevserver.postgres.database.azure.com/autodevops_e2e-branch?sslmode=require
   DB_URI: >-
-    postgresql://user_8843083%40samplenextappdevserver.postgres.database.azure.com:password_8843083@samplenextappdevserver.postgres.database.azure.com/autodevops_8843083?sslmode=require
+    postgresql://user_e2e-branch%40samplenextappdevserver.postgres.database.azure.com:password_e2e-branch@samplenextappdevserver.postgres.database.azure.com/autodevops_e2e-branch?sslmode=require
   HASURA_GRAPHQL_DATABASE_URL: >-
-    postgresql://user_8843083%40samplenextappdevserver.postgres.database.azure.com:password_8843083@samplenextappdevserver.postgres.database.azure.com/autodevops_8843083?sslmode=require
-  PGDATABASE: autodevops_8843083
+    postgresql://user_e2e-branch%40samplenextappdevserver.postgres.database.azure.com:password_e2e-branch@samplenextappdevserver.postgres.database.azure.com/autodevops_e2e-branch?sslmode=require
+  PGDATABASE: autodevops_e2e-branch
   PGHOST: samplenextappdevserver.postgres.database.azure.com
-  PGPASSWORD: password_8843083
+  PGPASSWORD: password_e2e-branch
   PGRST_DB_URI: >-
-    postgresql://user_8843083%40samplenextappdevserver.postgres.database.azure.com:password_8843083@samplenextappdevserver.postgres.database.azure.com/autodevops_8843083?sslmode=require
+    postgresql://user_e2e-branch%40samplenextappdevserver.postgres.database.azure.com:password_e2e-branch@samplenextappdevserver.postgres.database.azure.com/autodevops_e2e-branch?sslmode=require
   PGSSLMODE: require
-  PGUSER: user_8843083@samplenextappdevserver.postgres.database.azure.com
+  PGUSER: user_e2e-branch@samplenextappdevserver.postgres.database.azure.com
 metadata:
   annotations:
     app.gitlab.com/app: socialgouv-sample-next-app
@@ -259,6 +259,6 @@ metadata:
     owner: sample-next-app
     team: sample-next-app
     cert: wildcard
-  name: azure-pg-user-8843083
+  name: azure-pg-user-e2e-branch
   namespace: sample-next-app-24-e2e-branch-42"
 `;

--- a/e2e/templates/pgweb/kosko generate/__tests__/__snapshots__/--env dev.ts.snap
+++ b/e2e/templates/pgweb/kosko generate/__tests__/__snapshots__/--env dev.ts.snap
@@ -107,7 +107,7 @@ spec:
             - secretRef:
                 name: azure-pg-user-e2e-branch
           image: >-
-            registry.gitlab.factory.social.gouv.fr/socialgouv/docker/wait-for-postgres:4.3.1
+            registry.gitlab.factory.social.gouv.fr/socialgouv/docker/wait-for-postgres:4.7.1
           imagePullPolicy: Always
           name: wait-for-postgres
           resources:

--- a/e2e/templates/pgweb/kosko generate/__tests__/__snapshots__/--env preprod.ts.snap
+++ b/e2e/templates/pgweb/kosko generate/__tests__/__snapshots__/--env preprod.ts.snap
@@ -107,7 +107,7 @@ spec:
             - secretRef:
                 name: azure-pg-user
           image: >-
-            registry.gitlab.factory.social.gouv.fr/socialgouv/docker/wait-for-postgres:4.6.0
+            registry.gitlab.factory.social.gouv.fr/socialgouv/docker/wait-for-postgres:4.3.1
           imagePullPolicy: Always
           name: wait-for-postgres
           resources:

--- a/e2e/templates/pgweb/kosko generate/__tests__/__snapshots__/--env preprod.ts.snap
+++ b/e2e/templates/pgweb/kosko generate/__tests__/__snapshots__/--env preprod.ts.snap
@@ -107,7 +107,7 @@ spec:
             - secretRef:
                 name: azure-pg-user
           image: >-
-            registry.gitlab.factory.social.gouv.fr/socialgouv/docker/wait-for-postgres:4.3.1
+            registry.gitlab.factory.social.gouv.fr/socialgouv/docker/wait-for-postgres:4.7.1
           imagePullPolicy: Always
           name: wait-for-postgres
           resources:

--- a/e2e/templates/sample/kosko generate/__tests__/__snapshots__/--env dev.ts.snap
+++ b/e2e/templates/sample/kosko generate/__tests__/__snapshots__/--env dev.ts.snap
@@ -97,7 +97,7 @@ spec:
             periodSeconds: 5
           envFrom:
             - secretRef:
-                name: azure-pg-user-8843083
+                name: azure-pg-user-e2e-branch
             - configMapRef:
                 name: hasura-configmap
       initContainers:
@@ -106,9 +106,9 @@ spec:
               value: '24'
           envFrom:
             - secretRef:
-                name: azure-pg-user-8843083
+                name: azure-pg-user-e2e-branch
           image: >-
-            registry.gitlab.factory.social.gouv.fr/socialgouv/docker/wait-for-postgres:4.6.0
+            registry.gitlab.factory.social.gouv.fr/socialgouv/docker/wait-for-postgres:4.3.1
           imagePullPolicy: Always
           name: wait-for-postgres
           resources:
@@ -180,11 +180,11 @@ spec:
             - create-db-user
           env:
             - name: NEW_DB_NAME
-              value: autodevops_8843083
+              value: autodevops_e2e-branch
             - name: NEW_USER
-              value: user_8843083
+              value: user_e2e-branch
             - name: NEW_PASSWORD
-              value: password_8843083
+              value: password_e2e-branch
             - name: NEW_DB_EXTENSIONS
               value: hstore pgcrypto citext uuid-ossp
           envFrom:
@@ -223,25 +223,25 @@ metadata:
     owner: sample-next-app
     team: sample-next-app
     cert: wildcard
-  name: create-db-job-8843083
+  name: create-db-job-e2e-branch
   namespace: sample-next-app-24-e2e-branch-42
 ---
 apiVersion: v1
 kind: Secret
 stringData:
   DATABASE_URL: >-
-    postgresql://user_8843083%40samplenextappdevserver.postgres.database.azure.com:password_8843083@samplenextappdevserver.postgres.database.azure.com/autodevops_8843083?sslmode=require
+    postgresql://user_e2e-branch%40samplenextappdevserver.postgres.database.azure.com:password_e2e-branch@samplenextappdevserver.postgres.database.azure.com/autodevops_e2e-branch?sslmode=require
   DB_URI: >-
-    postgresql://user_8843083%40samplenextappdevserver.postgres.database.azure.com:password_8843083@samplenextappdevserver.postgres.database.azure.com/autodevops_8843083?sslmode=require
+    postgresql://user_e2e-branch%40samplenextappdevserver.postgres.database.azure.com:password_e2e-branch@samplenextappdevserver.postgres.database.azure.com/autodevops_e2e-branch?sslmode=require
   HASURA_GRAPHQL_DATABASE_URL: >-
-    postgresql://user_8843083%40samplenextappdevserver.postgres.database.azure.com:password_8843083@samplenextappdevserver.postgres.database.azure.com/autodevops_8843083?sslmode=require
-  PGDATABASE: autodevops_8843083
+    postgresql://user_e2e-branch%40samplenextappdevserver.postgres.database.azure.com:password_e2e-branch@samplenextappdevserver.postgres.database.azure.com/autodevops_e2e-branch?sslmode=require
+  PGDATABASE: autodevops_e2e-branch
   PGHOST: samplenextappdevserver.postgres.database.azure.com
-  PGPASSWORD: password_8843083
+  PGPASSWORD: password_e2e-branch
   PGRST_DB_URI: >-
-    postgresql://user_8843083%40samplenextappdevserver.postgres.database.azure.com:password_8843083@samplenextappdevserver.postgres.database.azure.com/autodevops_8843083?sslmode=require
+    postgresql://user_e2e-branch%40samplenextappdevserver.postgres.database.azure.com:password_e2e-branch@samplenextappdevserver.postgres.database.azure.com/autodevops_e2e-branch?sslmode=require
   PGSSLMODE: require
-  PGUSER: user_8843083@samplenextappdevserver.postgres.database.azure.com
+  PGUSER: user_e2e-branch@samplenextappdevserver.postgres.database.azure.com
 metadata:
   annotations:
     app.gitlab.com/app: socialgouv-sample-next-app
@@ -252,7 +252,7 @@ metadata:
     owner: sample-next-app
     team: sample-next-app
     cert: wildcard
-  name: azure-pg-user-8843083
+  name: azure-pg-user-e2e-branch
   namespace: sample-next-app-24-e2e-branch-42
 ---
 apiVersion: apps/v1
@@ -333,7 +333,7 @@ spec:
             periodSeconds: 5
           envFrom:
             - secretRef:
-                name: azure-pg-user-8843083
+                name: azure-pg-user-e2e-branch
             - configMapRef:
                 name: app-configmap
       initContainers:
@@ -342,9 +342,9 @@ spec:
               value: '24'
           envFrom:
             - secretRef:
-                name: azure-pg-user-8843083
+                name: azure-pg-user-e2e-branch
           image: >-
-            registry.gitlab.factory.social.gouv.fr/socialgouv/docker/wait-for-postgres:4.6.0
+            registry.gitlab.factory.social.gouv.fr/socialgouv/docker/wait-for-postgres:4.3.1
           imagePullPolicy: Always
           name: wait-for-postgres
           resources:

--- a/e2e/templates/sample/kosko generate/__tests__/__snapshots__/--env dev.ts.snap
+++ b/e2e/templates/sample/kosko generate/__tests__/__snapshots__/--env dev.ts.snap
@@ -108,7 +108,7 @@ spec:
             - secretRef:
                 name: azure-pg-user-e2e-branch
           image: >-
-            registry.gitlab.factory.social.gouv.fr/socialgouv/docker/wait-for-postgres:4.3.1
+            registry.gitlab.factory.social.gouv.fr/socialgouv/docker/wait-for-postgres:4.7.1
           imagePullPolicy: Always
           name: wait-for-postgres
           resources:
@@ -344,7 +344,7 @@ spec:
             - secretRef:
                 name: azure-pg-user-e2e-branch
           image: >-
-            registry.gitlab.factory.social.gouv.fr/socialgouv/docker/wait-for-postgres:4.3.1
+            registry.gitlab.factory.social.gouv.fr/socialgouv/docker/wait-for-postgres:4.7.1
           imagePullPolicy: Always
           name: wait-for-postgres
           resources:

--- a/e2e/templates/sample/kosko generate/__tests__/__snapshots__/--env preprod.ts.snap
+++ b/e2e/templates/sample/kosko generate/__tests__/__snapshots__/--env preprod.ts.snap
@@ -108,7 +108,7 @@ spec:
             - secretRef:
                 name: azure-pg-user
           image: >-
-            registry.gitlab.factory.social.gouv.fr/socialgouv/docker/wait-for-postgres:4.6.0
+            registry.gitlab.factory.social.gouv.fr/socialgouv/docker/wait-for-postgres:4.3.1
           imagePullPolicy: Always
           name: wait-for-postgres
           resources:
@@ -309,7 +309,7 @@ spec:
             - secretRef:
                 name: azure-pg-user
           image: >-
-            registry.gitlab.factory.social.gouv.fr/socialgouv/docker/wait-for-postgres:4.6.0
+            registry.gitlab.factory.social.gouv.fr/socialgouv/docker/wait-for-postgres:4.3.1
           imagePullPolicy: Always
           name: wait-for-postgres
           resources:

--- a/e2e/templates/sample/kosko generate/__tests__/__snapshots__/--env preprod.ts.snap
+++ b/e2e/templates/sample/kosko generate/__tests__/__snapshots__/--env preprod.ts.snap
@@ -108,7 +108,7 @@ spec:
             - secretRef:
                 name: azure-pg-user
           image: >-
-            registry.gitlab.factory.social.gouv.fr/socialgouv/docker/wait-for-postgres:4.3.1
+            registry.gitlab.factory.social.gouv.fr/socialgouv/docker/wait-for-postgres:4.7.1
           imagePullPolicy: Always
           name: wait-for-postgres
           resources:
@@ -309,7 +309,7 @@ spec:
             - secretRef:
                 name: azure-pg-user
           image: >-
-            registry.gitlab.factory.social.gouv.fr/socialgouv/docker/wait-for-postgres:4.3.1
+            registry.gitlab.factory.social.gouv.fr/socialgouv/docker/wait-for-postgres:4.7.1
           imagePullPolicy: Always
           name: wait-for-postgres
           resources:

--- a/e2e/templates/sample/kosko generate/__tests__/__snapshots__/--env prod.ts.snap
+++ b/e2e/templates/sample/kosko generate/__tests__/__snapshots__/--env prod.ts.snap
@@ -87,7 +87,7 @@ spec:
             - secretRef:
                 name: azure-pg-user
           image: >-
-            registry.gitlab.factory.social.gouv.fr/socialgouv/docker/wait-for-postgres:4.6.0
+            registry.gitlab.factory.social.gouv.fr/socialgouv/docker/wait-for-postgres:4.3.1
           imagePullPolicy: Always
           name: wait-for-postgres
           resources:
@@ -281,7 +281,7 @@ spec:
             - secretRef:
                 name: azure-pg-user
           image: >-
-            registry.gitlab.factory.social.gouv.fr/socialgouv/docker/wait-for-postgres:4.6.0
+            registry.gitlab.factory.social.gouv.fr/socialgouv/docker/wait-for-postgres:4.3.1
           imagePullPolicy: Always
           name: wait-for-postgres
           resources:

--- a/e2e/templates/sample/kosko generate/__tests__/__snapshots__/--env prod.ts.snap
+++ b/e2e/templates/sample/kosko generate/__tests__/__snapshots__/--env prod.ts.snap
@@ -87,7 +87,7 @@ spec:
             - secretRef:
                 name: azure-pg-user
           image: >-
-            registry.gitlab.factory.social.gouv.fr/socialgouv/docker/wait-for-postgres:4.3.1
+            registry.gitlab.factory.social.gouv.fr/socialgouv/docker/wait-for-postgres:4.7.1
           imagePullPolicy: Always
           name: wait-for-postgres
           resources:
@@ -281,7 +281,7 @@ spec:
             - secretRef:
                 name: azure-pg-user
           image: >-
-            registry.gitlab.factory.social.gouv.fr/socialgouv/docker/wait-for-postgres:4.3.1
+            registry.gitlab.factory.social.gouv.fr/socialgouv/docker/wait-for-postgres:4.7.1
           imagePullPolicy: Always
           name: wait-for-postgres
           resources:

--- a/src/components/azure-pg/__snapshots__/drop-autodevops-dbs.test.ts.snap
+++ b/src/components/azure-pg/__snapshots__/drop-autodevops-dbs.test.ts.snap
@@ -24,7 +24,7 @@ Object {
                 },
               },
             ],
-            "image": "registry.gitlab.factory.social.gouv.fr/socialgouv/docker/azure-db:4.6.0",
+            "image": "registry.gitlab.factory.social.gouv.fr/socialgouv/docker/azure-db:4.7.1",
             "imagePullPolicy": "IfNotPresent",
             "name": "drop-autodevops-dbs",
             "resources": Object {
@@ -70,7 +70,7 @@ Object {
                 },
               },
             ],
-            "image": "registry.gitlab.factory.social.gouv.fr/socialgouv/docker/azure-db:4.6.0",
+            "image": "registry.gitlab.factory.social.gouv.fr/socialgouv/docker/azure-db:4.7.1",
             "imagePullPolicy": "IfNotPresent",
             "name": "drop-autodevops-dbs",
             "resources": Object {

--- a/src/components/azure-pg/__snapshots__/index.test.ts.snap
+++ b/src/components/azure-pg/__snapshots__/index.test.ts.snap
@@ -15,7 +15,7 @@ Array [
         "owner": "sample",
         "team": "sample",
       },
-      "name": "create-db-job-abcdefg",
+      "name": "create-db-job-some-branch",
       "namespace": "sample-42-my-test",
     },
     "spec": Object {
@@ -41,15 +41,15 @@ Array [
               "env": Array [
                 Object {
                   "name": "NEW_DB_NAME",
-                  "value": "autodevops_abcdefg",
+                  "value": "autodevops_some-branch",
                 },
                 Object {
                   "name": "NEW_USER",
-                  "value": "user_abcdefg",
+                  "value": "user_some-branch",
                 },
                 Object {
                   "name": "NEW_PASSWORD",
-                  "value": "password_abcdefg",
+                  "value": "password_some-branch",
                 },
                 Object {
                   "name": "NEW_DB_EXTENSIONS",
@@ -97,19 +97,19 @@ Array [
         "owner": "sample",
         "team": "sample",
       },
-      "name": "azure-pg-user-abcdefg",
+      "name": "azure-pg-user-some-branch",
       "namespace": "sample-42-my-test",
     },
     "stringData": Object {
-      "DATABASE_URL": "postgresql://user_abcdefg%40sampledevserver.postgres.database.azure.com:password_abcdefg@sampledevserver.postgres.database.azure.com/autodevops_abcdefg?sslmode=require",
-      "DB_URI": "postgresql://user_abcdefg%40sampledevserver.postgres.database.azure.com:password_abcdefg@sampledevserver.postgres.database.azure.com/autodevops_abcdefg?sslmode=require",
-      "HASURA_GRAPHQL_DATABASE_URL": "postgresql://user_abcdefg%40sampledevserver.postgres.database.azure.com:password_abcdefg@sampledevserver.postgres.database.azure.com/autodevops_abcdefg?sslmode=require",
-      "PGDATABASE": "autodevops_abcdefg",
+      "DATABASE_URL": "postgresql://user_some-branch%40sampledevserver.postgres.database.azure.com:password_some-branch@sampledevserver.postgres.database.azure.com/autodevops_some-branch?sslmode=require",
+      "DB_URI": "postgresql://user_some-branch%40sampledevserver.postgres.database.azure.com:password_some-branch@sampledevserver.postgres.database.azure.com/autodevops_some-branch?sslmode=require",
+      "HASURA_GRAPHQL_DATABASE_URL": "postgresql://user_some-branch%40sampledevserver.postgres.database.azure.com:password_some-branch@sampledevserver.postgres.database.azure.com/autodevops_some-branch?sslmode=require",
+      "PGDATABASE": "autodevops_some-branch",
       "PGHOST": "sampledevserver.postgres.database.azure.com",
-      "PGPASSWORD": "password_abcdefg",
-      "PGRST_DB_URI": "postgresql://user_abcdefg%40sampledevserver.postgres.database.azure.com:password_abcdefg@sampledevserver.postgres.database.azure.com/autodevops_abcdefg?sslmode=require",
+      "PGPASSWORD": "password_some-branch",
+      "PGRST_DB_URI": "postgresql://user_some-branch%40sampledevserver.postgres.database.azure.com:password_some-branch@sampledevserver.postgres.database.azure.com/autodevops_some-branch?sslmode=require",
       "PGSSLMODE": "require",
-      "PGUSER": "user_abcdefg@sampledevserver.postgres.database.azure.com",
+      "PGUSER": "user_some-branch@sampledevserver.postgres.database.azure.com",
     },
   },
 ]
@@ -117,6 +117,7 @@ Array [
 
 exports[`should throw because of a missing envs 1`] = `
 "Wrong environment variables
+required \\"CI_COMMIT_REF_SLUG\\": \\"undefined\\" should be defined
 required \\"CI_COMMIT_SHORT_SHA\\": \\"undefined\\" should be defined
 required \\"CI_PROJECT_NAME\\": \\"undefined\\" should be defined
 "
@@ -137,7 +138,7 @@ Array [
         "owner": "sample",
         "team": "sample",
       },
-      "name": "create-db-job-abcdefg",
+      "name": "create-db-job-some-branch",
       "namespace": "sample-42-my-test",
     },
     "spec": Object {
@@ -163,15 +164,15 @@ Array [
               "env": Array [
                 Object {
                   "name": "NEW_DB_NAME",
-                  "value": "autodevops_abcdefg",
+                  "value": "autodevops_some-branch",
                 },
                 Object {
                   "name": "NEW_USER",
-                  "value": "user_abcdefg",
+                  "value": "user_some-branch",
                 },
                 Object {
                   "name": "NEW_PASSWORD",
-                  "value": "password_abcdefg",
+                  "value": "password_some-branch",
                 },
                 Object {
                   "name": "NEW_DB_EXTENSIONS",
@@ -219,19 +220,19 @@ Array [
         "owner": "sample",
         "team": "sample",
       },
-      "name": "azure-pg-user-abcdefg",
+      "name": "azure-pg-user-some-branch",
       "namespace": "sample-42-my-test",
     },
     "stringData": Object {
-      "DATABASE_URL": "postgresql://user_abcdefg%40pouetpouet.com:password_abcdefg@pouetpouet.com/autodevops_abcdefg?sslmode=require",
-      "DB_URI": "postgresql://user_abcdefg%40pouetpouet.com:password_abcdefg@pouetpouet.com/autodevops_abcdefg?sslmode=require",
-      "HASURA_GRAPHQL_DATABASE_URL": "postgresql://user_abcdefg%40pouetpouet.com:password_abcdefg@pouetpouet.com/autodevops_abcdefg?sslmode=require",
-      "PGDATABASE": "autodevops_abcdefg",
+      "DATABASE_URL": "postgresql://user_some-branch%40pouetpouet.com:password_some-branch@pouetpouet.com/autodevops_some-branch?sslmode=require",
+      "DB_URI": "postgresql://user_some-branch%40pouetpouet.com:password_some-branch@pouetpouet.com/autodevops_some-branch?sslmode=require",
+      "HASURA_GRAPHQL_DATABASE_URL": "postgresql://user_some-branch%40pouetpouet.com:password_some-branch@pouetpouet.com/autodevops_some-branch?sslmode=require",
+      "PGDATABASE": "autodevops_some-branch",
       "PGHOST": "pouetpouet.com",
-      "PGPASSWORD": "password_abcdefg",
-      "PGRST_DB_URI": "postgresql://user_abcdefg%40pouetpouet.com:password_abcdefg@pouetpouet.com/autodevops_abcdefg?sslmode=require",
+      "PGPASSWORD": "password_some-branch",
+      "PGRST_DB_URI": "postgresql://user_some-branch%40pouetpouet.com:password_some-branch@pouetpouet.com/autodevops_some-branch?sslmode=require",
       "PGSSLMODE": "require",
-      "PGUSER": "user_abcdefg@pouetpouet.com",
+      "PGUSER": "user_some-branch@pouetpouet.com",
     },
   },
 ]

--- a/src/components/azure-pg/__snapshots__/restore-db.job.test.ts.snap
+++ b/src/components/azure-pg/__snapshots__/restore-db.job.test.ts.snap
@@ -110,7 +110,7 @@ psql -v ON_ERROR_STOP=1 \${PGDATABASE} -c \\"ALTER SCHEMA public owner to \${OWN
                 },
               ],
               "envFrom": Array [],
-              "image": "registry.gitlab.factory.social.gouv.fr/socialgouv/docker/wait-for-postgres:4.6.0",
+              "image": "registry.gitlab.factory.social.gouv.fr/socialgouv/docker/wait-for-postgres:4.7.1",
               "imagePullPolicy": "Always",
               "name": "wait-for-postgres",
               "resources": Object {
@@ -269,7 +269,7 @@ psql -v ON_ERROR_STOP=1 \${PGDATABASE} -c \\"ALTER SCHEMA public owner to \${OWN
                 },
               ],
               "envFrom": Array [],
-              "image": "registry.gitlab.factory.social.gouv.fr/socialgouv/docker/wait-for-postgres:4.6.0",
+              "image": "registry.gitlab.factory.social.gouv.fr/socialgouv/docker/wait-for-postgres:4.7.1",
               "imagePullPolicy": "Always",
               "name": "wait-for-postgres",
               "resources": Object {

--- a/src/components/azure-pg/__snapshots__/restore-db.job.test.ts.snap
+++ b/src/components/azure-pg/__snapshots__/restore-db.job.test.ts.snap
@@ -94,15 +94,15 @@ psql -v ON_ERROR_STOP=1 \${PGDATABASE} -c \\"ALTER SCHEMA public owner to \${OWN
                 },
                 Object {
                   "name": "PGDATABASE",
-                  "value": "autodevops_b123a99",
+                  "value": "autodevops_some-branch",
                 },
                 Object {
                   "name": "PGPASSWORD",
-                  "value": "password_b123a99",
+                  "value": "password_some-branch",
                 },
                 Object {
                   "name": "PGUSER",
-                  "value": "user_b123a99@someappdevserver.postgres.database.azure.com",
+                  "value": "user_some-branch@someappdevserver.postgres.database.azure.com",
                 },
                 Object {
                   "name": "PGSSLMODE",
@@ -253,15 +253,15 @@ psql -v ON_ERROR_STOP=1 \${PGDATABASE} -c \\"ALTER SCHEMA public owner to \${OWN
                 },
                 Object {
                   "name": "PGDATABASE",
-                  "value": "autodevops_b123a99",
+                  "value": "autodevops_some-branch",
                 },
                 Object {
                   "name": "PGPASSWORD",
-                  "value": "password_b123a99",
+                  "value": "password_some-branch",
                 },
                 Object {
                   "name": "PGUSER",
-                  "value": "user_b123a99@someappdevserver.postgres.database.azure.com",
+                  "value": "user_some-branch@someappdevserver.postgres.database.azure.com",
                 },
                 Object {
                   "name": "PGSSLMODE",

--- a/src/components/azure-pg/create-db.job.test.ts
+++ b/src/components/azure-pg/create-db.job.test.ts
@@ -2,6 +2,7 @@ import { createDbJob } from "./create-db.job";
 
 test("should create a pg secret", () => {
   process.env.CI_COMMIT_SHORT_SHA = "1234567";
+  process.env.CI_COMMIT_REF_SLUG = "some-branch";
   const job = createDbJob({
     database: "some-db",
     password: "my-password",

--- a/src/components/azure-pg/drop-autodevops-dbs.test.ts
+++ b/src/components/azure-pg/drop-autodevops-dbs.test.ts
@@ -1,6 +1,7 @@
 import { dropAutodevopsDbsJob } from "./drop-autodevops-dbs.job";
 
 process.env.CI_COMMIT_SHORT_SHA = "b123a99";
+process.env.CI_COMMIT_REF_SLUG = "some-branch";
 
 test("should use some-secret for running drop-autodevops-dbs", () => {
   expect(

--- a/src/components/azure-pg/drop-db.job.test.ts
+++ b/src/components/azure-pg/drop-db.job.test.ts
@@ -2,6 +2,7 @@ import { dropDbJob } from "./drop-db.job";
 
 test("should create a pg secret", () => {
   process.env.CI_COMMIT_SHORT_SHA = "1234567";
+  process.env.CI_COMMIT_REF_SLUG = "some-branch";
   const job = dropDbJob({
     database: "some-db",
     user: "tester",

--- a/src/components/azure-pg/drop-db.test.ts
+++ b/src/components/azure-pg/drop-db.test.ts
@@ -1,6 +1,7 @@
 import { dropDbJob } from "./drop-db.job";
 
 process.env.CI_COMMIT_SHORT_SHA = "b123a99";
+process.env.CI_COMMIT_REF_SLUG = "some-branch";
 
 test("should customize secret and extensions when running drop-db", () => {
   expect(

--- a/src/components/azure-pg/index.test.ts
+++ b/src/components/azure-pg/index.test.ts
@@ -8,6 +8,7 @@ import { create } from "./index";
 
 const gitlabEnv = {
   CI_COMMIT_SHORT_SHA: "abcdefg",
+  CI_COMMIT_REF_SLUG: "some-branch",
   CI_ENVIRONMENT_NAME: "fabrique-dev",
   CI_ENVIRONMENT_SLUG: "my-test",
   CI_PROJECT_NAME: "sample",

--- a/src/components/azure-pg/index.test.ts
+++ b/src/components/azure-pg/index.test.ts
@@ -7,8 +7,8 @@ import { directory } from "tempy";
 import { create } from "./index";
 
 const gitlabEnv = {
-  CI_COMMIT_SHORT_SHA: "abcdefg",
   CI_COMMIT_REF_SLUG: "some-branch",
+  CI_COMMIT_SHORT_SHA: "abcdefg",
   CI_ENVIRONMENT_NAME: "fabrique-dev",
   CI_ENVIRONMENT_SLUG: "my-test",
   CI_PROJECT_NAME: "sample",

--- a/src/components/azure-pg/index.ts
+++ b/src/components/azure-pg/index.ts
@@ -10,7 +10,11 @@ import { createDbJob } from "./create-db.job";
 import { getDevDatabaseParameters } from "./params";
 import type { PgParams } from "./types";
 
-const assert = assertEnv(["CI_COMMIT_SHORT_SHA", "CI_PROJECT_NAME"]);
+const assert = assertEnv([
+  "CI_COMMIT_REF_SLUG",
+  "CI_COMMIT_SHORT_SHA",
+  "CI_PROJECT_NAME",
+]);
 
 export const getDefaultPgParams = (
   config: Partial<CreateConfig> = {}
@@ -18,6 +22,7 @@ export const getDefaultPgParams = (
   assert(process.env);
 
   const {
+    CI_COMMIT_REF_SLUG: branch,
     CI_COMMIT_SHORT_SHA: sha,
     CI_PROJECT_NAME: projectName,
     // NOTE(douglasduteil): enforce defined string in process.env
@@ -26,10 +31,10 @@ export const getDefaultPgParams = (
 
   return {
     ...getDevDatabaseParameters({
-      suffix: sha,
+      suffix: branch,
     }),
     host: config.pgHost ?? getPgServerHostname(projectName, "dev"),
-    name: `azure-pg-user-${sha}`,
+    name: `azure-pg-user-${branch}`,
   };
 };
 
@@ -56,7 +61,7 @@ export const create = ({ config = {} }: CreateParams): { kind: string }[] => {
   updateMetadata(job, {
     annotations: envParams.annotations ?? {},
     labels: envParams.labels ?? {},
-    name: `create-db-job-${process.env.CI_COMMIT_SHORT_SHA}`,
+    name: `create-db-job-${process.env.CI_COMMIT_REF_SLUG}`,
     namespace: envParams.namespace,
   });
 

--- a/src/components/azure-pg/index.ts
+++ b/src/components/azure-pg/index.ts
@@ -23,7 +23,6 @@ export const getDefaultPgParams = (
 
   const {
     CI_COMMIT_REF_SLUG: branch,
-    CI_COMMIT_SHORT_SHA: sha,
     CI_PROJECT_NAME: projectName,
     // NOTE(douglasduteil): enforce defined string in process.env
     // Those env variables are asserted to be defined above

--- a/src/components/azure-pg/restore-db.job.test.ts
+++ b/src/components/azure-pg/restore-db.job.test.ts
@@ -5,6 +5,7 @@ import { restoreDbJob } from "./restore-db.job";
 process.env.CI_COMMIT_SHORT_SHA = "b123a99";
 process.env.CI_PROJECT_NAME = "some-app";
 process.env.CI_JOB_ID = "123456789";
+process.env.CI_COMMIT_REF_SLUG = "some-branch";
 
 test("should create restore DB job", () => {
   expect(

--- a/src/utils/__snapshots__/waitForHttp.test.ts.snap
+++ b/src/utils/__snapshots__/waitForHttp.test.ts.snap
@@ -5,7 +5,7 @@ Object {
   "args": Array [
     "http://service:4242",
   ],
-  "image": "registry.gitlab.factory.social.gouv.fr/socialgouv/docker/wait-for-http:4.6.0",
+  "image": "registry.gitlab.factory.social.gouv.fr/socialgouv/docker/wait-for-http:4.7.1",
   "imagePullPolicy": "Always",
   "name": "wait-for-some-service",
   "resources": Object {

--- a/templates/hasura/environments/.gitlab-ci.env
+++ b/templates/hasura/environments/.gitlab-ci.env
@@ -2,6 +2,7 @@
 # This is a snapshot of the GitLab env from the SocialGouv/sample-next-app
 #
 CI_COMMIT_REF_NAME=e2e-branch
+CI_COMMIT_REF_SLUG=e2e-branch
 CI_ENVIRONMENT_NAME=e2e-branch-dev2
 CI_ENVIRONMENT_SLUG=e2e-branch-42
 CI_ENVIRONMENT_URL=https://e2e-branch-dev2-sample-next-app.dev2.fabrique.social.gouv.fr

--- a/templates/nginx/environments/.gitlab-ci.env
+++ b/templates/nginx/environments/.gitlab-ci.env
@@ -4,6 +4,7 @@
 CI_COMMIT_REF_NAME=e2e-branch
 CI_ENVIRONMENT_NAME=e2e-branch-dev2
 CI_ENVIRONMENT_SLUG=e2e-branch-42
+CI_COMMIT_REF_SLUG=e2e-branch
 CI_ENVIRONMENT_URL=https://e2e-branch-dev2-sample-kosko.dev2.fabrique.social.gouv.fr
 CI_PROJECT_NAME=sample-kosko
 CI_PROJECT_PATH_SLUG=socialgouv-sample-kosko

--- a/templates/pgweb/environments/.gitlab-ci.env
+++ b/templates/pgweb/environments/.gitlab-ci.env
@@ -2,6 +2,7 @@
 # This is a snapshot of the GitLab env from the SocialGouv/sample-next-app
 #
 CI_COMMIT_REF_NAME=e2e-branch
+CI_COMMIT_REF_SLUG=e2e-branch
 CI_ENVIRONMENT_NAME=e2e-branch-dev2
 CI_ENVIRONMENT_SLUG=e2e-branch-42
 CI_ENVIRONMENT_URL=https://e2e-branch-dev2-sample-next-app.dev2.fabrique.social.gouv.fr

--- a/templates/redis/environments/.gitlab-ci.env
+++ b/templates/redis/environments/.gitlab-ci.env
@@ -3,6 +3,7 @@
 #
 CI_COMMIT_REF_NAME=e2e-branch
 CI_ENVIRONMENT_NAME=e2e-branch-dev2
+CI_COMMIT_REF_SLUG=e2e-branch
 CI_ENVIRONMENT_SLUG=e2e-branch-42
 CI_ENVIRONMENT_URL=https://e2e-branch-dev2-sample-kosko.dev2.fabrique.social.gouv.fr
 CI_PROJECT_NAME=sample-kosko

--- a/templates/sample/environments/.gitlab-ci.env
+++ b/templates/sample/environments/.gitlab-ci.env
@@ -2,6 +2,7 @@
 # This is a snapshot of the GitLab env from the SocialGouv/sample-next-app
 #
 CI_COMMIT_REF_NAME=e2e-branch
+CI_COMMIT_REF_SLUG=e2e-branch
 CI_ENVIRONMENT_NAME=e2e-branch-dev2
 CI_ENVIRONMENT_SLUG=e2e-branch-42
 CI_ENVIRONMENT_URL=https://e2e-branch-dev2-sample-next-app.dev2.fabrique.social.gouv.fr


### PR DESCRIPTION
This changes how ephemeral databases and users are named in the autodevops pipeline
it will now use the `CI_COMMIT_REF_SLUG` suffix instead of `CI_COMMIT_SHORT_SHA`

BREAKING CHANGE ?