### PR TITLE
revert(pkg)!: restore kubernetes-models a direct dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,10 @@
   "author": "Fabrique numérique des Ministères Sociaux <dsi-incubateur@sg.social.gouv.fr> (https://incubateur.social.gouv.fr)",
   "bugs": "https://github.com/SocialGouv/kosko-charts/issues",
   "dependencies": {
+    "@kubernetes-models/sealed-secrets": "^1.6.3",
     "@sindresorhus/is": "^4.0.1",
     "fs-extra": "^10.0.0",
+    "kubernetes-models": "^1.7.1",
     "slugify": "^1.6.0"
   },
   "devDependencies": {
@@ -14,7 +16,6 @@
     "@babel/preset-env": "^7.14.8",
     "@babel/preset-typescript": "^7.14.5",
     "@kosko/env": "^2.0.1",
-    "@kubernetes-models/sealed-secrets": "^1.6.3",
     "@socialgouv/eslint-config-recommended": "^1.82.0",
     "@socialgouv/eslint-config-typescript": "^1.82.0",
     "@socialgouv/kosko-charts": "link:./",
@@ -30,7 +31,6 @@
     "jest": "^27.0.6",
     "jest-file-snapshot": "^0.5.0",
     "kosko": "^1.1.5",
-    "kubernetes-models": "^1.7.1",
     "lint-staged": "^11.1.0",
     "onchange": "^7.1.0",
     "prettier": "^2.3.2",
@@ -57,9 +57,7 @@
     ]
   },
   "peerDependencies": {
-    "@kosko/env": "2",
-    "@kubernetes-models/sealed-secrets": "1",
-    "kubernetes-models": "1"
+    "@kosko/env": "2"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
<img width=100% src=https://thumbs.gfycat.com/BareAccomplishedHoki-size_restricted.gif />

---

BREAKING CHANGE: You will now need to manually remove conflicting kosko related dependencies !

As we are now inline with the latest `kosko` version, we can restore the versioning responsibility on our side.

revert #477