### PR TITLE
v9.0.0-beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,58 @@
+# [9.0.0-beta.1](https://github.com/SocialGouv/kosko-charts/compare/v8.1.1...v9.0.0-beta.1) (2021-07-29)
+
+
+* feat(azure-pg)!: use one database per branch (#624) ([a0883a3](https://github.com/SocialGouv/kosko-charts/commit/a0883a3df670349d11f9902faeb9c83b5d87d993)), closes [#624](https://github.com/SocialGouv/kosko-charts/issues/624)
+
+
+### BREAKING CHANGES
+
+* Our create database component is now creating one database per branch
+
+Previously our `@socialgouv/kosko-charts/components/azure-pg` component was creating one database per commit. As it happen to be a rare need at @SocialGouv, we now switch to one database per branch.
+* Unify commen `pg.ts` component use under the same function
+
+Previously our `@socialgouv/kosko-charts/components/azure-pg` component was only handling the "dev"/"review" use case where we have to create the database and the user ourself. This ends up putting on the user land the responsibility of manually loading a sealedsecret in other case. As it happen to be a common need at @SocialGouv, we now deal with loading the file our creating the database as before if the named file does not exist.
+
+```diff
+import env from "@kosko/env";
+-import type { SealedSecret } from "@kubernetes-models/sealed-secrets/bitnami.com/v1alpha1/SealedSecret";
+ import { create } from "@socialgouv/kosko-charts/components/azure-pg";
+-import environments from "@socialgouv/kosko-charts/environments";
+-import { loadYaml } from "@socialgouv/kosko-charts/utils/getEnvironmentComponent";
+-import { updateMetadata } from "@socialgouv/kosko-charts/utils/updateMetadata";
+
++export default create("pg-user", {
++  env,
++});
+-export default async (): Promise<{ kind: string }[]> => {
+-  if (env.env === "dev") {
+-    return create({
+-      env,
+-    });
+-  }
+-
+-  // in prod/preprod, we try to add a fixed sealed-secret
+-  const secret = await loadYaml<SealedSecret>(
+-    env,
+-    `pg-user.sealed-secret.yaml`
+-  );
+-  if (!secret) {
+-    return [];
+-  }
+-
+-  const envParams = environments(process.env);
+-  // add gitlab annotations
+-  updateMetadata(secret, {
+-    annotations: envParams.metadata.annotations ?? {},
+-    labels: envParams.metadata.labels ?? {},
+-    namespace: envParams.metadata.namespace,
+-  });
+-  return [secret];
+-};
+```
+
+The new `create` function of `@socialgouv/kosko-charts/components/azure-pg` takes a `name` as fist argument used to "guest" the file to load `${name}.sealed-secret.yaml` is the given env (as before)
+
 ## [8.1.1](https://github.com/SocialGouv/kosko-charts/compare/v8.1.0...v8.1.1) (2021-07-29)
 
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Providing a common Kubernetes (k8s) configuration to SocialGouv apps is a tricky
 Powered by [Kosko](https://github.com/tommy351/kosko), in this lib we provide default SocialGouv components and environments. We expect project to use and extend them at will.
 
 ```sh
-$ npx degit "SocialGouv/kosko-charts/templates/sample#v8.1.1" .k8s
+$ npx degit "SocialGouv/kosko-charts/templates/sample#v9.0.0-beta.1" .k8s
 $ yarn --cwd .k8s
 # on GitLab
 $ yarn --cwd .k8s kosko generate --env dev
@@ -59,7 +59,7 @@ $ DOTENV_CONFIG_PATH=environments/.gitlab-ci.env yarn --cwd .k8s dev --require d
 We use [degit](https://github.com/Rich-Harris/degit) to scaffold the deployment config.
 
 ```sh
-$ npx degit "SocialGouv/kosko-charts/templates/sample#v8.1.1" .k8s
+$ npx degit "SocialGouv/kosko-charts/templates/sample#v9.0.0-beta.1" .k8s
 ```
 
 `.k8s` is the target deployment config package folder.
@@ -131,16 +131,16 @@ In addition to the `sample` template inspired by the [SocialGouv/sample-next-app
 
 ```sh
 # For [hasura](https://hasura.io/)
-$ npx degit "SocialGouv/kosko-charts/templates/hasura#v8.1.1" .k8s
+$ npx degit "SocialGouv/kosko-charts/templates/hasura#v9.0.0-beta.1" .k8s
 
 # For [nginx](https://nginx.org/)
-$ npx degit "SocialGouv/kosko-charts/templates/nginx#v8.1.1" .k8s
+$ npx degit "SocialGouv/kosko-charts/templates/nginx#v9.0.0-beta.1" .k8s
 
 # For [pgweb](https://sosedoff.github.io/pgweb/)
-$ npx degit "SocialGouv/kosko-charts/templates/pgweb#v8.1.1" .k8s
+$ npx degit "SocialGouv/kosko-charts/templates/pgweb#v9.0.0-beta.1" .k8s
 
 # For [redis](https://redislabs.com/)
-$ npx degit "SocialGouv/kosko-charts/templates/redis#v8.1.1" .k8s
+$ npx degit "SocialGouv/kosko-charts/templates/redis#v9.0.0-beta.1" .k8s
 ```
 
 ### Testing
@@ -149,7 +149,7 @@ $ npx degit "SocialGouv/kosko-charts/templates/redis#v8.1.1" .k8s
 
 ```
 # At the root of your project
-$ npx degit "SocialGouv/kosko-charts/templates/testing#v8.1.1" .k8s
+$ npx degit "SocialGouv/kosko-charts/templates/testing#v9.0.0-beta.1" .k8s
 ```
 
 Then update the `.k8s/__tests__` file to match your project.  

--- a/e2e/kitchen-sink/__tests__/__snapshots__/multihost.ts.snap
+++ b/e2e/kitchen-sink/__tests__/__snapshots__/multihost.ts.snap
@@ -96,7 +96,7 @@ spec:
             periodSeconds: 5
           envFrom:
             - secretRef:
-                name: azure-pg-user-8843083
+                name: azure-pg-user-e2e-branch-42
       imagePullSecrets:
         - name: regcred
       initContainers:
@@ -105,7 +105,7 @@ spec:
               value: '24'
           envFrom:
             - secretRef:
-                name: azure-pg-user-8843083
+                name: azure-pg-user-e2e-branch-42
           image: ghcr.io/socialgouv/docker/wait-for-postgres:6.32.2
           imagePullPolicy: Always
           name: wait-for-postgres
@@ -221,7 +221,7 @@ spec:
             periodSeconds: 5
           envFrom:
             - secretRef:
-                name: azure-pg-user-8843083
+                name: azure-pg-user-e2e-branch-42
       imagePullSecrets:
         - name: some-secret
       initContainers:
@@ -230,7 +230,7 @@ spec:
               value: '24'
           envFrom:
             - secretRef:
-                name: azure-pg-user-8843083
+                name: azure-pg-user-e2e-branch-42
           image: ghcr.io/socialgouv/docker/wait-for-postgres:6.32.2
           imagePullPolicy: Always
           name: wait-for-postgres

--- a/e2e/templates/hasura/kosko generate/__tests__/__snapshots__/--env dev github.ts.snap
+++ b/e2e/templates/hasura/kosko generate/__tests__/__snapshots__/--env dev github.ts.snap
@@ -102,7 +102,7 @@ spec:
             periodSeconds: 5
           envFrom:
             - secretRef:
-                name: azure-pg-user-8843083
+                name: azure-pg-user-e2e-branch
             - configMapRef:
                 name: hasura-configmap
       initContainers:
@@ -111,7 +111,7 @@ spec:
               value: '24'
           envFrom:
             - secretRef:
-                name: azure-pg-user-8843083
+                name: azure-pg-user-e2e-branch
           image: ghcr.io/socialgouv/docker/wait-for-postgres:6.32.2
           imagePullPolicy: Always
           name: wait-for-postgres
@@ -224,11 +224,11 @@ spec:
             - create-db-user
           env:
             - name: NEW_DB_NAME
-              value: autodevops_8843083
+              value: autodevops_e2e-branch
             - name: NEW_USER
-              value: user_8843083
+              value: user_e2e-branch
             - name: NEW_PASSWORD
-              value: password_8843083
+              value: password_e2e-branch
             - name: NEW_DB_EXTENSIONS
               value: hstore pgcrypto citext uuid-ossp
           envFrom:
@@ -277,18 +277,18 @@ apiVersion: v1
 kind: Secret
 stringData:
   DATABASE_URL: >-
-    postgresql://user_8843083%40samplenextappdevserver.postgres.database.azure.com:password_8843083@samplenextappdevserver.postgres.database.azure.com/autodevops_8843083?sslmode=require
+    postgresql://user_e2e-branch%40samplenextappdevserver.postgres.database.azure.com:password_e2e-branch@samplenextappdevserver.postgres.database.azure.com/autodevops_e2e-branch?sslmode=require
   DB_URI: >-
-    postgresql://user_8843083%40samplenextappdevserver.postgres.database.azure.com:password_8843083@samplenextappdevserver.postgres.database.azure.com/autodevops_8843083?sslmode=require
+    postgresql://user_e2e-branch%40samplenextappdevserver.postgres.database.azure.com:password_e2e-branch@samplenextappdevserver.postgres.database.azure.com/autodevops_e2e-branch?sslmode=require
   HASURA_GRAPHQL_DATABASE_URL: >-
-    postgresql://user_8843083%40samplenextappdevserver.postgres.database.azure.com:password_8843083@samplenextappdevserver.postgres.database.azure.com/autodevops_8843083?sslmode=require
-  PGDATABASE: autodevops_8843083
+    postgresql://user_e2e-branch%40samplenextappdevserver.postgres.database.azure.com:password_e2e-branch@samplenextappdevserver.postgres.database.azure.com/autodevops_e2e-branch?sslmode=require
+  PGDATABASE: autodevops_e2e-branch
   PGHOST: samplenextappdevserver.postgres.database.azure.com
-  PGPASSWORD: password_8843083
+  PGPASSWORD: password_e2e-branch
   PGRST_DB_URI: >-
-    postgresql://user_8843083%40samplenextappdevserver.postgres.database.azure.com:password_8843083@samplenextappdevserver.postgres.database.azure.com/autodevops_8843083?sslmode=require
+    postgresql://user_e2e-branch%40samplenextappdevserver.postgres.database.azure.com:password_e2e-branch@samplenextappdevserver.postgres.database.azure.com/autodevops_e2e-branch?sslmode=require
   PGSSLMODE: require
-  PGUSER: user_8843083@samplenextappdevserver.postgres.database.azure.com
+  PGUSER: user_e2e-branch@samplenextappdevserver.postgres.database.azure.com
 metadata:
   annotations:
     app.github.com/job: xxxxxxx-job
@@ -301,6 +301,6 @@ metadata:
     owner: sample-next-app
     team: sample-next-app
     cert: wildcard
-  name: azure-pg-user-8843083
+  name: azure-pg-user-e2e-branch
   namespace: sample-next-app-e2e-branch"
 `;

--- a/e2e/templates/hasura/kosko generate/__tests__/__snapshots__/--env dev.ts.snap
+++ b/e2e/templates/hasura/kosko generate/__tests__/__snapshots__/--env dev.ts.snap
@@ -96,7 +96,7 @@ spec:
             periodSeconds: 5
           envFrom:
             - secretRef:
-                name: azure-pg-user-8843083
+                name: azure-pg-user-e2e-branch-42
             - configMapRef:
                 name: hasura-configmap
       initContainers:
@@ -105,7 +105,7 @@ spec:
               value: '24'
           envFrom:
             - secretRef:
-                name: azure-pg-user-8843083
+                name: azure-pg-user-e2e-branch-42
           image: ghcr.io/socialgouv/docker/wait-for-postgres:6.32.2
           imagePullPolicy: Always
           name: wait-for-postgres
@@ -212,11 +212,11 @@ spec:
             - create-db-user
           env:
             - name: NEW_DB_NAME
-              value: autodevops_8843083
+              value: autodevops_e2e-branch-42
             - name: NEW_USER
-              value: user_8843083
+              value: user_e2e-branch-42
             - name: NEW_PASSWORD
-              value: password_8843083
+              value: password_e2e-branch-42
             - name: NEW_DB_EXTENSIONS
               value: hstore pgcrypto citext uuid-ossp
           envFrom:
@@ -261,18 +261,18 @@ apiVersion: v1
 kind: Secret
 stringData:
   DATABASE_URL: >-
-    postgresql://user_8843083%40samplenextappdevserver.postgres.database.azure.com:password_8843083@samplenextappdevserver.postgres.database.azure.com/autodevops_8843083?sslmode=require
+    postgresql://user_e2e-branch-42%40samplenextappdevserver.postgres.database.azure.com:password_e2e-branch-42@samplenextappdevserver.postgres.database.azure.com/autodevops_e2e-branch-42?sslmode=require
   DB_URI: >-
-    postgresql://user_8843083%40samplenextappdevserver.postgres.database.azure.com:password_8843083@samplenextappdevserver.postgres.database.azure.com/autodevops_8843083?sslmode=require
+    postgresql://user_e2e-branch-42%40samplenextappdevserver.postgres.database.azure.com:password_e2e-branch-42@samplenextappdevserver.postgres.database.azure.com/autodevops_e2e-branch-42?sslmode=require
   HASURA_GRAPHQL_DATABASE_URL: >-
-    postgresql://user_8843083%40samplenextappdevserver.postgres.database.azure.com:password_8843083@samplenextappdevserver.postgres.database.azure.com/autodevops_8843083?sslmode=require
-  PGDATABASE: autodevops_8843083
+    postgresql://user_e2e-branch-42%40samplenextappdevserver.postgres.database.azure.com:password_e2e-branch-42@samplenextappdevserver.postgres.database.azure.com/autodevops_e2e-branch-42?sslmode=require
+  PGDATABASE: autodevops_e2e-branch-42
   PGHOST: samplenextappdevserver.postgres.database.azure.com
-  PGPASSWORD: password_8843083
+  PGPASSWORD: password_e2e-branch-42
   PGRST_DB_URI: >-
-    postgresql://user_8843083%40samplenextappdevserver.postgres.database.azure.com:password_8843083@samplenextappdevserver.postgres.database.azure.com/autodevops_8843083?sslmode=require
+    postgresql://user_e2e-branch-42%40samplenextappdevserver.postgres.database.azure.com:password_e2e-branch-42@samplenextappdevserver.postgres.database.azure.com/autodevops_e2e-branch-42?sslmode=require
   PGSSLMODE: require
-  PGUSER: user_8843083@samplenextappdevserver.postgres.database.azure.com
+  PGUSER: user_e2e-branch-42@samplenextappdevserver.postgres.database.azure.com
 metadata:
   annotations:
     app.gitlab.com/app: socialgouv-sample-next-app
@@ -283,6 +283,6 @@ metadata:
     owner: sample-next-app
     team: sample-next-app
     cert: wildcard
-  name: azure-pg-user-8843083
+  name: azure-pg-user-e2e-branch-42
   namespace: sample-next-app-24-e2e-branch-42"
 `;

--- a/e2e/templates/pgweb/kosko generate/__tests__/__snapshots__/--env dev github.ts.snap
+++ b/e2e/templates/pgweb/kosko generate/__tests__/__snapshots__/--env dev github.ts.snap
@@ -104,14 +104,14 @@ spec:
             periodSeconds: 5
           envFrom:
             - secretRef:
-                name: azure-pg-user-8843083
+                name: azure-pg-user-e2e-branch
       initContainers:
         - env:
             - name: WAIT_FOR_RETRIES
               value: '24'
           envFrom:
             - secretRef:
-                name: azure-pg-user-8843083
+                name: azure-pg-user-e2e-branch
           image: ghcr.io/socialgouv/docker/wait-for-postgres:6.32.2
           imagePullPolicy: Always
           name: wait-for-postgres
@@ -199,11 +199,11 @@ spec:
             - create-db-user
           env:
             - name: NEW_DB_NAME
-              value: autodevops_8843083
+              value: autodevops_e2e-branch
             - name: NEW_USER
-              value: user_8843083
+              value: user_e2e-branch
             - name: NEW_PASSWORD
-              value: password_8843083
+              value: password_e2e-branch
             - name: NEW_DB_EXTENSIONS
               value: hstore pgcrypto citext uuid-ossp
           envFrom:
@@ -252,18 +252,18 @@ apiVersion: v1
 kind: Secret
 stringData:
   DATABASE_URL: >-
-    postgresql://user_8843083%40samplenextappdevserver.postgres.database.azure.com:password_8843083@samplenextappdevserver.postgres.database.azure.com/autodevops_8843083?sslmode=require
+    postgresql://user_e2e-branch%40samplenextappdevserver.postgres.database.azure.com:password_e2e-branch@samplenextappdevserver.postgres.database.azure.com/autodevops_e2e-branch?sslmode=require
   DB_URI: >-
-    postgresql://user_8843083%40samplenextappdevserver.postgres.database.azure.com:password_8843083@samplenextappdevserver.postgres.database.azure.com/autodevops_8843083?sslmode=require
+    postgresql://user_e2e-branch%40samplenextappdevserver.postgres.database.azure.com:password_e2e-branch@samplenextappdevserver.postgres.database.azure.com/autodevops_e2e-branch?sslmode=require
   HASURA_GRAPHQL_DATABASE_URL: >-
-    postgresql://user_8843083%40samplenextappdevserver.postgres.database.azure.com:password_8843083@samplenextappdevserver.postgres.database.azure.com/autodevops_8843083?sslmode=require
-  PGDATABASE: autodevops_8843083
+    postgresql://user_e2e-branch%40samplenextappdevserver.postgres.database.azure.com:password_e2e-branch@samplenextappdevserver.postgres.database.azure.com/autodevops_e2e-branch?sslmode=require
+  PGDATABASE: autodevops_e2e-branch
   PGHOST: samplenextappdevserver.postgres.database.azure.com
-  PGPASSWORD: password_8843083
+  PGPASSWORD: password_e2e-branch
   PGRST_DB_URI: >-
-    postgresql://user_8843083%40samplenextappdevserver.postgres.database.azure.com:password_8843083@samplenextappdevserver.postgres.database.azure.com/autodevops_8843083?sslmode=require
+    postgresql://user_e2e-branch%40samplenextappdevserver.postgres.database.azure.com:password_e2e-branch@samplenextappdevserver.postgres.database.azure.com/autodevops_e2e-branch?sslmode=require
   PGSSLMODE: require
-  PGUSER: user_8843083@samplenextappdevserver.postgres.database.azure.com
+  PGUSER: user_e2e-branch@samplenextappdevserver.postgres.database.azure.com
 metadata:
   annotations:
     app.github.com/job: xxxxxxx-job
@@ -276,6 +276,6 @@ metadata:
     owner: sample-next-app
     team: sample-next-app
     cert: wildcard
-  name: azure-pg-user-8843083
+  name: azure-pg-user-e2e-branch
   namespace: sample-next-app-e2e-branch"
 `;

--- a/e2e/templates/pgweb/kosko generate/__tests__/__snapshots__/--env dev.ts.snap
+++ b/e2e/templates/pgweb/kosko generate/__tests__/__snapshots__/--env dev.ts.snap
@@ -98,14 +98,14 @@ spec:
             periodSeconds: 5
           envFrom:
             - secretRef:
-                name: azure-pg-user-8843083
+                name: azure-pg-user-e2e-branch-42
       initContainers:
         - env:
             - name: WAIT_FOR_RETRIES
               value: '24'
           envFrom:
             - secretRef:
-                name: azure-pg-user-8843083
+                name: azure-pg-user-e2e-branch-42
           image: ghcr.io/socialgouv/docker/wait-for-postgres:6.32.2
           imagePullPolicy: Always
           name: wait-for-postgres
@@ -189,11 +189,11 @@ spec:
             - create-db-user
           env:
             - name: NEW_DB_NAME
-              value: autodevops_8843083
+              value: autodevops_e2e-branch-42
             - name: NEW_USER
-              value: user_8843083
+              value: user_e2e-branch-42
             - name: NEW_PASSWORD
-              value: password_8843083
+              value: password_e2e-branch-42
             - name: NEW_DB_EXTENSIONS
               value: hstore pgcrypto citext uuid-ossp
           envFrom:
@@ -238,18 +238,18 @@ apiVersion: v1
 kind: Secret
 stringData:
   DATABASE_URL: >-
-    postgresql://user_8843083%40samplenextappdevserver.postgres.database.azure.com:password_8843083@samplenextappdevserver.postgres.database.azure.com/autodevops_8843083?sslmode=require
+    postgresql://user_e2e-branch-42%40samplenextappdevserver.postgres.database.azure.com:password_e2e-branch-42@samplenextappdevserver.postgres.database.azure.com/autodevops_e2e-branch-42?sslmode=require
   DB_URI: >-
-    postgresql://user_8843083%40samplenextappdevserver.postgres.database.azure.com:password_8843083@samplenextappdevserver.postgres.database.azure.com/autodevops_8843083?sslmode=require
+    postgresql://user_e2e-branch-42%40samplenextappdevserver.postgres.database.azure.com:password_e2e-branch-42@samplenextappdevserver.postgres.database.azure.com/autodevops_e2e-branch-42?sslmode=require
   HASURA_GRAPHQL_DATABASE_URL: >-
-    postgresql://user_8843083%40samplenextappdevserver.postgres.database.azure.com:password_8843083@samplenextappdevserver.postgres.database.azure.com/autodevops_8843083?sslmode=require
-  PGDATABASE: autodevops_8843083
+    postgresql://user_e2e-branch-42%40samplenextappdevserver.postgres.database.azure.com:password_e2e-branch-42@samplenextappdevserver.postgres.database.azure.com/autodevops_e2e-branch-42?sslmode=require
+  PGDATABASE: autodevops_e2e-branch-42
   PGHOST: samplenextappdevserver.postgres.database.azure.com
-  PGPASSWORD: password_8843083
+  PGPASSWORD: password_e2e-branch-42
   PGRST_DB_URI: >-
-    postgresql://user_8843083%40samplenextappdevserver.postgres.database.azure.com:password_8843083@samplenextappdevserver.postgres.database.azure.com/autodevops_8843083?sslmode=require
+    postgresql://user_e2e-branch-42%40samplenextappdevserver.postgres.database.azure.com:password_e2e-branch-42@samplenextappdevserver.postgres.database.azure.com/autodevops_e2e-branch-42?sslmode=require
   PGSSLMODE: require
-  PGUSER: user_8843083@samplenextappdevserver.postgres.database.azure.com
+  PGUSER: user_e2e-branch-42@samplenextappdevserver.postgres.database.azure.com
 metadata:
   annotations:
     app.gitlab.com/app: socialgouv-sample-next-app
@@ -260,6 +260,6 @@ metadata:
     owner: sample-next-app
     team: sample-next-app
     cert: wildcard
-  name: azure-pg-user-8843083
+  name: azure-pg-user-e2e-branch-42
   namespace: sample-next-app-24-e2e-branch-42"
 `;

--- a/e2e/templates/sample/kosko generate/__tests__/__snapshots__/--env dev github.ts.snap
+++ b/e2e/templates/sample/kosko generate/__tests__/__snapshots__/--env dev github.ts.snap
@@ -102,7 +102,7 @@ spec:
             periodSeconds: 5
           envFrom:
             - secretRef:
-                name: azure-pg-user-8843083
+                name: azure-pg-user-e2e-branch
             - configMapRef:
                 name: hasura-configmap
       initContainers:
@@ -111,7 +111,7 @@ spec:
               value: '24'
           envFrom:
             - secretRef:
-                name: azure-pg-user-8843083
+                name: azure-pg-user-e2e-branch
           image: ghcr.io/socialgouv/docker/wait-for-postgres:6.32.2
           imagePullPolicy: Always
           name: wait-for-postgres
@@ -188,11 +188,11 @@ spec:
             - create-db-user
           env:
             - name: NEW_DB_NAME
-              value: autodevops_8843083
+              value: autodevops_e2e-branch
             - name: NEW_USER
-              value: user_8843083
+              value: user_e2e-branch
             - name: NEW_PASSWORD
-              value: password_8843083
+              value: password_e2e-branch
             - name: NEW_DB_EXTENSIONS
               value: hstore pgcrypto citext uuid-ossp
           envFrom:
@@ -241,18 +241,18 @@ apiVersion: v1
 kind: Secret
 stringData:
   DATABASE_URL: >-
-    postgresql://user_8843083%40samplenextappdevserver.postgres.database.azure.com:password_8843083@samplenextappdevserver.postgres.database.azure.com/autodevops_8843083?sslmode=require
+    postgresql://user_e2e-branch%40samplenextappdevserver.postgres.database.azure.com:password_e2e-branch@samplenextappdevserver.postgres.database.azure.com/autodevops_e2e-branch?sslmode=require
   DB_URI: >-
-    postgresql://user_8843083%40samplenextappdevserver.postgres.database.azure.com:password_8843083@samplenextappdevserver.postgres.database.azure.com/autodevops_8843083?sslmode=require
+    postgresql://user_e2e-branch%40samplenextappdevserver.postgres.database.azure.com:password_e2e-branch@samplenextappdevserver.postgres.database.azure.com/autodevops_e2e-branch?sslmode=require
   HASURA_GRAPHQL_DATABASE_URL: >-
-    postgresql://user_8843083%40samplenextappdevserver.postgres.database.azure.com:password_8843083@samplenextappdevserver.postgres.database.azure.com/autodevops_8843083?sslmode=require
-  PGDATABASE: autodevops_8843083
+    postgresql://user_e2e-branch%40samplenextappdevserver.postgres.database.azure.com:password_e2e-branch@samplenextappdevserver.postgres.database.azure.com/autodevops_e2e-branch?sslmode=require
+  PGDATABASE: autodevops_e2e-branch
   PGHOST: samplenextappdevserver.postgres.database.azure.com
-  PGPASSWORD: password_8843083
+  PGPASSWORD: password_e2e-branch
   PGRST_DB_URI: >-
-    postgresql://user_8843083%40samplenextappdevserver.postgres.database.azure.com:password_8843083@samplenextappdevserver.postgres.database.azure.com/autodevops_8843083?sslmode=require
+    postgresql://user_e2e-branch%40samplenextappdevserver.postgres.database.azure.com:password_e2e-branch@samplenextappdevserver.postgres.database.azure.com/autodevops_e2e-branch?sslmode=require
   PGSSLMODE: require
-  PGUSER: user_8843083@samplenextappdevserver.postgres.database.azure.com
+  PGUSER: user_e2e-branch@samplenextappdevserver.postgres.database.azure.com
 metadata:
   annotations:
     app.github.com/job: xxxxxxx-job
@@ -265,7 +265,7 @@ metadata:
     owner: sample-next-app
     team: sample-next-app
     cert: wildcard
-  name: azure-pg-user-8843083
+  name: azure-pg-user-e2e-branch
   namespace: sample-next-app-e2e-branch
 ---
 apiVersion: apps/v1
@@ -349,7 +349,7 @@ spec:
             periodSeconds: 5
           envFrom:
             - secretRef:
-                name: azure-pg-user-8843083
+                name: azure-pg-user-e2e-branch
             - configMapRef:
                 name: app-configmap
       initContainers:
@@ -358,7 +358,7 @@ spec:
               value: '24'
           envFrom:
             - secretRef:
-                name: azure-pg-user-8843083
+                name: azure-pg-user-e2e-branch
           image: ghcr.io/socialgouv/docker/wait-for-postgres:6.32.2
           imagePullPolicy: Always
           name: wait-for-postgres

--- a/e2e/templates/sample/kosko generate/__tests__/__snapshots__/--env dev.ts.snap
+++ b/e2e/templates/sample/kosko generate/__tests__/__snapshots__/--env dev.ts.snap
@@ -96,7 +96,7 @@ spec:
             periodSeconds: 5
           envFrom:
             - secretRef:
-                name: azure-pg-user-8843083
+                name: azure-pg-user-e2e-branch-42
             - configMapRef:
                 name: hasura-configmap
       initContainers:
@@ -105,7 +105,7 @@ spec:
               value: '24'
           envFrom:
             - secretRef:
-                name: azure-pg-user-8843083
+                name: azure-pg-user-e2e-branch-42
           image: ghcr.io/socialgouv/docker/wait-for-postgres:6.32.2
           imagePullPolicy: Always
           name: wait-for-postgres
@@ -178,11 +178,11 @@ spec:
             - create-db-user
           env:
             - name: NEW_DB_NAME
-              value: autodevops_8843083
+              value: autodevops_e2e-branch-42
             - name: NEW_USER
-              value: user_8843083
+              value: user_e2e-branch-42
             - name: NEW_PASSWORD
-              value: password_8843083
+              value: password_e2e-branch-42
             - name: NEW_DB_EXTENSIONS
               value: hstore pgcrypto citext uuid-ossp
           envFrom:
@@ -227,18 +227,18 @@ apiVersion: v1
 kind: Secret
 stringData:
   DATABASE_URL: >-
-    postgresql://user_8843083%40samplenextappdevserver.postgres.database.azure.com:password_8843083@samplenextappdevserver.postgres.database.azure.com/autodevops_8843083?sslmode=require
+    postgresql://user_e2e-branch-42%40samplenextappdevserver.postgres.database.azure.com:password_e2e-branch-42@samplenextappdevserver.postgres.database.azure.com/autodevops_e2e-branch-42?sslmode=require
   DB_URI: >-
-    postgresql://user_8843083%40samplenextappdevserver.postgres.database.azure.com:password_8843083@samplenextappdevserver.postgres.database.azure.com/autodevops_8843083?sslmode=require
+    postgresql://user_e2e-branch-42%40samplenextappdevserver.postgres.database.azure.com:password_e2e-branch-42@samplenextappdevserver.postgres.database.azure.com/autodevops_e2e-branch-42?sslmode=require
   HASURA_GRAPHQL_DATABASE_URL: >-
-    postgresql://user_8843083%40samplenextappdevserver.postgres.database.azure.com:password_8843083@samplenextappdevserver.postgres.database.azure.com/autodevops_8843083?sslmode=require
-  PGDATABASE: autodevops_8843083
+    postgresql://user_e2e-branch-42%40samplenextappdevserver.postgres.database.azure.com:password_e2e-branch-42@samplenextappdevserver.postgres.database.azure.com/autodevops_e2e-branch-42?sslmode=require
+  PGDATABASE: autodevops_e2e-branch-42
   PGHOST: samplenextappdevserver.postgres.database.azure.com
-  PGPASSWORD: password_8843083
+  PGPASSWORD: password_e2e-branch-42
   PGRST_DB_URI: >-
-    postgresql://user_8843083%40samplenextappdevserver.postgres.database.azure.com:password_8843083@samplenextappdevserver.postgres.database.azure.com/autodevops_8843083?sslmode=require
+    postgresql://user_e2e-branch-42%40samplenextappdevserver.postgres.database.azure.com:password_e2e-branch-42@samplenextappdevserver.postgres.database.azure.com/autodevops_e2e-branch-42?sslmode=require
   PGSSLMODE: require
-  PGUSER: user_8843083@samplenextappdevserver.postgres.database.azure.com
+  PGUSER: user_e2e-branch-42@samplenextappdevserver.postgres.database.azure.com
 metadata:
   annotations:
     app.gitlab.com/app: socialgouv-sample-next-app
@@ -249,7 +249,7 @@ metadata:
     owner: sample-next-app
     team: sample-next-app
     cert: wildcard
-  name: azure-pg-user-8843083
+  name: azure-pg-user-e2e-branch-42
   namespace: sample-next-app-24-e2e-branch-42
 ---
 apiVersion: apps/v1
@@ -330,7 +330,7 @@ spec:
             periodSeconds: 5
           envFrom:
             - secretRef:
-                name: azure-pg-user-8843083
+                name: azure-pg-user-e2e-branch-42
             - configMapRef:
                 name: app-configmap
       initContainers:
@@ -339,7 +339,7 @@ spec:
               value: '24'
           envFrom:
             - secretRef:
-                name: azure-pg-user-8843083
+                name: azure-pg-user-e2e-branch-42
           image: ghcr.io/socialgouv/docker/wait-for-postgres:6.32.2
           imagePullPolicy: Always
           name: wait-for-postgres

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@socialgouv/kosko-charts",
   "description": "Kosko charts for the SocialGouv needs",
-  "version": "8.1.1",
+  "version": "9.0.0-beta.1",
   "author": "Fabrique numérique des Ministères Sociaux <dsi-incubateur@sg.social.gouv.fr> (https://incubateur.social.gouv.fr)",
   "bugs": "https://github.com/SocialGouv/kosko-charts/issues",
   "dependencies": {

--- a/src/components/app/__snapshots__/index.test.ts.snap
+++ b/src/components/app/__snapshots__/index.test.ts.snap
@@ -236,7 +236,7 @@ Array [
               "envFrom": Array [
                 Object {
                   "secretRef": Object {
-                    "name": "azure-pg-user-0123456",
+                    "name": "azure-pg-user-my-test",
                   },
                 },
               ],
@@ -300,7 +300,7 @@ Array [
               "envFrom": Array [
                 Object {
                   "secretRef": Object {
-                    "name": "azure-pg-user-0123456",
+                    "name": "azure-pg-user-my-test",
                   },
                 },
               ],

--- a/src/components/app/index.test.ts
+++ b/src/components/app/index.test.ts
@@ -4,6 +4,7 @@ import { promises } from "fs";
 import { directory } from "tempy";
 
 const gitlabMock: CIEnv = {
+  environment: "my-test",
   isPreProduction: false,
   isProduction: false,
   metadata: {

--- a/src/components/azure-pg/__snapshots__/index.test.ts.snap
+++ b/src/components/azure-pg/__snapshots__/index.test.ts.snap
@@ -15,7 +15,7 @@ Array [
         "owner": "sample",
         "team": "sample",
       },
-      "name": "create-db-job-abcdefg",
+      "name": "create-db-job-0123456",
       "namespace": "sample-42-my-test",
     },
     "spec": Object {
@@ -41,15 +41,15 @@ Array [
               "env": Array [
                 Object {
                   "name": "NEW_DB_NAME",
-                  "value": "autodevops_abcdefg",
+                  "value": "autodevops_my-test",
                 },
                 Object {
                   "name": "NEW_USER",
-                  "value": "user_abcdefg",
+                  "value": "user_my-test",
                 },
                 Object {
                   "name": "NEW_PASSWORD",
-                  "value": "password_abcdefg",
+                  "value": "password_my-test",
                 },
                 Object {
                   "name": "NEW_DB_EXTENSIONS",
@@ -97,36 +97,22 @@ Array [
         "owner": "sample",
         "team": "sample",
       },
-      "name": "azure-pg-user-abcdefg",
+      "name": "azure-pg-user-my-test",
       "namespace": "sample-42-my-test",
     },
     "stringData": Object {
-      "DATABASE_URL": "postgresql://user_abcdefg%40sampledevserver.postgres.database.azure.com:password_abcdefg@sampledevserver.postgres.database.azure.com/autodevops_abcdefg?sslmode=require",
-      "DB_URI": "postgresql://user_abcdefg%40sampledevserver.postgres.database.azure.com:password_abcdefg@sampledevserver.postgres.database.azure.com/autodevops_abcdefg?sslmode=require",
-      "HASURA_GRAPHQL_DATABASE_URL": "postgresql://user_abcdefg%40sampledevserver.postgres.database.azure.com:password_abcdefg@sampledevserver.postgres.database.azure.com/autodevops_abcdefg?sslmode=require",
-      "PGDATABASE": "autodevops_abcdefg",
+      "DATABASE_URL": "postgresql://user_my-test%40sampledevserver.postgres.database.azure.com:password_my-test@sampledevserver.postgres.database.azure.com/autodevops_my-test?sslmode=require",
+      "DB_URI": "postgresql://user_my-test%40sampledevserver.postgres.database.azure.com:password_my-test@sampledevserver.postgres.database.azure.com/autodevops_my-test?sslmode=require",
+      "HASURA_GRAPHQL_DATABASE_URL": "postgresql://user_my-test%40sampledevserver.postgres.database.azure.com:password_my-test@sampledevserver.postgres.database.azure.com/autodevops_my-test?sslmode=require",
+      "PGDATABASE": "autodevops_my-test",
       "PGHOST": "sampledevserver.postgres.database.azure.com",
-      "PGPASSWORD": "password_abcdefg",
-      "PGRST_DB_URI": "postgresql://user_abcdefg%40sampledevserver.postgres.database.azure.com:password_abcdefg@sampledevserver.postgres.database.azure.com/autodevops_abcdefg?sslmode=require",
+      "PGPASSWORD": "password_my-test",
+      "PGRST_DB_URI": "postgresql://user_my-test%40sampledevserver.postgres.database.azure.com:password_my-test@sampledevserver.postgres.database.azure.com/autodevops_my-test?sslmode=require",
       "PGSSLMODE": "require",
-      "PGUSER": "user_abcdefg@sampledevserver.postgres.database.azure.com",
+      "PGUSER": "user_my-test@sampledevserver.postgres.database.azure.com",
     },
   },
 ]
-`;
-
-exports[`should throw because of a missing envs 1`] = `
-"Wrong environment variables
-required \\"CI_ENVIRONMENT_NAME\\": \\"undefined\\" should be defined
-required \\"CI_ENVIRONMENT_SLUG\\": \\"undefined\\" should be defined
-required \\"CI_PROJECT_NAME\\": \\"undefined\\" should be defined
-required \\"CI_PROJECT_PATH_SLUG\\": \\"undefined\\" should be defined
-required \\"KUBE_INGRESS_BASE_DOMAIN\\": \\"undefined\\" should be defined
-required \\"KUBE_NAMESPACE\\": \\"undefined\\" should be defined
-required \\"CI_COMMIT_SHORT_SHA\\": \\"undefined\\" should be defined
-required \\"CI_COMMIT_SHA\\": \\"undefined\\" should be defined
-required \\"CI_REGISTRY_IMAGE\\": \\"undefined\\" should be defined
-"
 `;
 
 exports[`should use custom pgHost 1`] = `
@@ -144,7 +130,7 @@ Array [
         "owner": "sample",
         "team": "sample",
       },
-      "name": "create-db-job-abcdefg",
+      "name": "create-db-job-0123456",
       "namespace": "sample-42-my-test",
     },
     "spec": Object {
@@ -170,15 +156,15 @@ Array [
               "env": Array [
                 Object {
                   "name": "NEW_DB_NAME",
-                  "value": "autodevops_abcdefg",
+                  "value": "autodevops_my-test",
                 },
                 Object {
                   "name": "NEW_USER",
-                  "value": "user_abcdefg",
+                  "value": "user_my-test",
                 },
                 Object {
                   "name": "NEW_PASSWORD",
-                  "value": "password_abcdefg",
+                  "value": "password_my-test",
                 },
                 Object {
                   "name": "NEW_DB_EXTENSIONS",
@@ -226,19 +212,19 @@ Array [
         "owner": "sample",
         "team": "sample",
       },
-      "name": "azure-pg-user-abcdefg",
+      "name": "azure-pg-user-my-test",
       "namespace": "sample-42-my-test",
     },
     "stringData": Object {
-      "DATABASE_URL": "postgresql://user_abcdefg%40pouetpouet.com:password_abcdefg@pouetpouet.com/autodevops_abcdefg?sslmode=require",
-      "DB_URI": "postgresql://user_abcdefg%40pouetpouet.com:password_abcdefg@pouetpouet.com/autodevops_abcdefg?sslmode=require",
-      "HASURA_GRAPHQL_DATABASE_URL": "postgresql://user_abcdefg%40pouetpouet.com:password_abcdefg@pouetpouet.com/autodevops_abcdefg?sslmode=require",
-      "PGDATABASE": "autodevops_abcdefg",
+      "DATABASE_URL": "postgresql://user_my-test%40pouetpouet.com:password_my-test@pouetpouet.com/autodevops_my-test?sslmode=require",
+      "DB_URI": "postgresql://user_my-test%40pouetpouet.com:password_my-test@pouetpouet.com/autodevops_my-test?sslmode=require",
+      "HASURA_GRAPHQL_DATABASE_URL": "postgresql://user_my-test%40pouetpouet.com:password_my-test@pouetpouet.com/autodevops_my-test?sslmode=require",
+      "PGDATABASE": "autodevops_my-test",
       "PGHOST": "pouetpouet.com",
-      "PGPASSWORD": "password_abcdefg",
-      "PGRST_DB_URI": "postgresql://user_abcdefg%40pouetpouet.com:password_abcdefg@pouetpouet.com/autodevops_abcdefg?sslmode=require",
+      "PGPASSWORD": "password_my-test",
+      "PGRST_DB_URI": "postgresql://user_my-test%40pouetpouet.com:password_my-test@pouetpouet.com/autodevops_my-test?sslmode=require",
       "PGSSLMODE": "require",
-      "PGUSER": "user_abcdefg@pouetpouet.com",
+      "PGUSER": "user_my-test@pouetpouet.com",
     },
   },
 ]

--- a/src/components/azure-pg/__snapshots__/restore-db.job.test.ts.snap
+++ b/src/components/azure-pg/__snapshots__/restore-db.job.test.ts.snap
@@ -6,7 +6,7 @@ Array [
     "apiVersion": "batch/v1",
     "kind": "Job",
     "metadata": Object {
-      "name": "restore-db-abcdefg",
+      "name": "restore-db-0123456",
       "namespace": "sample-next-app-secret",
     },
     "spec": Object {
@@ -94,15 +94,15 @@ psql -v ON_ERROR_STOP=1 \${PGDATABASE} -c \\"ALTER SCHEMA public owner to \${OWN
                 },
                 Object {
                   "name": "PGDATABASE",
-                  "value": "autodevops_abcdefg",
+                  "value": "autodevops_my-test",
                 },
                 Object {
                   "name": "PGPASSWORD",
-                  "value": "password_abcdefg",
+                  "value": "password_my-test",
                 },
                 Object {
                   "name": "PGUSER",
-                  "value": "user_abcdefg@sampledevserver.postgres.database.azure.com",
+                  "value": "user_my-test@sampledevserver.postgres.database.azure.com",
                 },
                 Object {
                   "name": "PGSSLMODE",
@@ -218,7 +218,7 @@ Array [
     },
     "kind": "ConfigMap",
     "metadata": Object {
-      "name": "post-restore-script-configmap-abcdefg",
+      "name": "post-restore-script-configmap-0123456",
       "namespace": "sample-next-app-secret",
     },
   },
@@ -226,7 +226,7 @@ Array [
     "apiVersion": "batch/v1",
     "kind": "Job",
     "metadata": Object {
-      "name": "restore-db-abcdefg",
+      "name": "restore-db-0123456",
       "namespace": "sample-next-app-secret",
     },
     "spec": Object {
@@ -318,15 +318,15 @@ psql -v ON_ERROR_STOP=1 \${PGDATABASE} -c \\"ALTER SCHEMA public owner to \${OWN
                 },
                 Object {
                   "name": "PGDATABASE",
-                  "value": "autodevops_abcdefg",
+                  "value": "autodevops_my-test",
                 },
                 Object {
                   "name": "PGPASSWORD",
-                  "value": "password_abcdefg",
+                  "value": "password_my-test",
                 },
                 Object {
                   "name": "PGUSER",
-                  "value": "user_abcdefg@sampledevserver.postgres.database.azure.com",
+                  "value": "user_my-test@sampledevserver.postgres.database.azure.com",
                 },
                 Object {
                   "name": "PGSSLMODE",
@@ -360,7 +360,7 @@ psql -v ON_ERROR_STOP=1 \${PGDATABASE} -c \\"ALTER SCHEMA public owner to \${OWN
             },
             Object {
               "configMap": Object {
-                "name": "post-restore-script-configmap-abcdefg",
+                "name": "post-restore-script-configmap-0123456",
               },
               "name": "scripts",
             },

--- a/src/components/azure-pg/create-db.job.ts
+++ b/src/components/azure-pg/create-db.job.ts
@@ -19,7 +19,7 @@ export const createDbJob = ({
   secretRefName?: string;
   user: string;
 }): Job => {
-  const job = new Job({
+  return new Job({
     spec: {
       backoffLimit: 5,
       template: {
@@ -73,5 +73,4 @@ export const createDbJob = ({
       ttlSecondsAfterFinished: 86400,
     },
   });
-  return job;
 };

--- a/src/components/azure-pg/index.test.ts
+++ b/src/components/azure-pg/index.test.ts
@@ -1,59 +1,17 @@
 //
 
+import {} from "@jest/globals";
 import { createNodeCJSEnvironment } from "@kosko/env";
+import environmentMock from "@socialgouv/kosko-charts/environments/index.mock";
 import { promises } from "fs";
 import { directory } from "tempy";
-
-const gitlabEnv = {
-  CI_COMMIT_SHORT_SHA: "abcdefg",
-  CI_ENVIRONMENT_NAME: "fabrique-dev",
-  CI_ENVIRONMENT_SLUG: "my-test",
-  CI_PROJECT_NAME: "sample",
-  CI_PROJECT_PATH_SLUG: "socialgouv-sample",
-  CI_REGISTRY_IMAGE: "registry.gitlab.factory.social.gouv.fr/socialgouv/sample",
-  KUBE_INGRESS_BASE_DOMAIN: "dev2.fabrique.social.gouv.fr",
-  KUBE_NAMESPACE: "sample-42-my-test",
-};
-
-const gitlabMock = {
-  metadata: {
-    annotations: {
-      "app.gitlab.com/app": "socialgouv-sample",
-      "app.gitlab.com/env": "my-test",
-    },
-    labels: {
-      application: "sample",
-      owner: "sample",
-      team: "sample",
-    },
-    namespace: { name: "sample-42-my-test" },
-  },
-  projectName: "sample",
-  shortSha: "abcdefg",
-};
-
-const gitlabModuleMock = {
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  __esModule: true,
-  default: () => gitlabMock,
-};
 
 beforeEach(() => {
   jest.resetModules();
 });
 
-test("should throw because of a missing envs", async () => {
-  const env = createNodeCJSEnvironment({ cwd: "/tmp" });
-  const { create } = await import("./index");
-  expect(() => create({ env })).toThrowErrorMatchingSnapshot();
-});
-
 test("should return create an job", async () => {
-  jest.doMock(
-    "@socialgouv/kosko-charts/environments/gitlab",
-    () => gitlabModuleMock
-  );
-  Object.assign(process.env, gitlabEnv);
+  jest.doMock("@socialgouv/kosko-charts/environments", () => environmentMock);
   const cwd = directory();
   const env = createNodeCJSEnvironment({ cwd });
   env.env = "dev";
@@ -63,15 +21,11 @@ test("should return create an job", async () => {
     "---\napiVersion: v1\nkind: ConfigMap"
   );
   const { create } = await import("./index");
-  expect(create({ env })).toMatchSnapshot();
+  expect(await create("foo", { env })).toMatchSnapshot();
 });
 
 test("should use custom pgHost", async () => {
-  jest.doMock(
-    "@socialgouv/kosko-charts/environments/gitlab",
-    () => gitlabModuleMock
-  );
-  process.env.CI_PROJECT_NAME = "sample-next-app";
+  jest.doMock("@socialgouv/kosko-charts/environments", () => environmentMock);
   const env = createNodeCJSEnvironment({ cwd: "/tmp/xxx" });
   env.env = "dev";
   await promises.mkdir(`/tmp/xxx/environments/dev`, { recursive: true });
@@ -81,6 +35,6 @@ test("should use custom pgHost", async () => {
   );
   const { create } = await import("./index");
   expect(
-    create({ config: { pgHost: "pouetpouet.com" }, env })
+    await create("foo", { config: { pgHost: "pouetpouet.com" }, env })
   ).toMatchSnapshot();
 });

--- a/src/components/azure-pg/restore-db.job.test.ts
+++ b/src/components/azure-pg/restore-db.job.test.ts
@@ -1,38 +1,9 @@
+import environmentMock from "@socialgouv/kosko-charts/environments/index.mock";
 import { EnvVar } from "kubernetes-models/v1";
 
-import { restoreDbJob } from "./restore-db.job";
-
-process.env.CI_COMMIT_SHORT_SHA = "b123a99";
-process.env.CI_PROJECT_NAME = "some-app";
-process.env.CI_JOB_ID = "123456789";
-process.env.CI_ENVIRONMENT_NAME = "fabrique-dev";
-process.env.CI_ENVIRONMENT_SLUG = "my-test";
-process.env.CI_PROJECT_PATH_SLUG = "socialgouv-sample";
-process.env.KUBE_INGRESS_BASE_DOMAIN = "dev2.fabrique.social.gouv.fr";
-process.env.KUBE_NAMESPACE = "sample-42-my-test";
-
-jest.mock("@socialgouv/kosko-charts/environments/gitlab", () => ({
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  __esModule: true,
-  default: () => ({
-    metadata: {
-      annotations: {
-        "app.gitlab.com/app": "socialgouv-sample",
-        "app.gitlab.com/env": "my-test",
-      },
-      labels: {
-        application: "sample",
-        owner: "sample",
-        team: "sample",
-      },
-      namespace: { name: "sample-42-my-test" },
-    },
-    projectName: "sample",
-    shortSha: "abcdefg",
-  }),
-}));
-
-test("should create restore DB job", () => {
+test("should create restore DB job", async () => {
+  jest.doMock("@socialgouv/kosko-charts/environments", () => environmentMock);
+  const { restoreDbJob } = await import("./restore-db.job");
   expect(
     restoreDbJob({
       env: [
@@ -54,7 +25,9 @@ test("should create restore DB job", () => {
   ).toMatchSnapshot();
 });
 
-test("should create restore DB job with post-restore script", () => {
+test("should create restore DB job with post-restore script", async () => {
+  jest.doMock("@socialgouv/kosko-charts/environments", () => environmentMock);
+  const { restoreDbJob } = await import("./restore-db.job");
   expect(
     restoreDbJob({
       env: [

--- a/src/components/azure-pg/restore-db.job.ts
+++ b/src/components/azure-pg/restore-db.job.ts
@@ -67,8 +67,6 @@ export const restoreDbJob = ({
   envFrom = [],
   postRestoreScript,
 }: RestoreDbJobArgs): { metadata?: IObjectMeta; kind: string }[] => {
-  // ok(process.env.CI_COMMIT_SHORT_SHA);
-  // ok(process.env.CI_JOB_ID);
   const ciEnv = environments(process.env);
   const secretNamespace = getProjectSecretNamespace(project);
   const azureSecretName = getAzureProdVolumeSecretName(project);

--- a/src/environments/github/__snapshots__/index.test.ts.snap
+++ b/src/environments/github/__snapshots__/index.test.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`should return preproduction tagged github global env 1`] = `
 Object {
+  "environment": "vx-y-z-25jxw5",
   "isPreProduction": true,
   "isProduction": false,
   "metadata": Object {
@@ -39,6 +40,7 @@ Object {
 
 exports[`should return production github global env 1`] = `
 Object {
+  "environment": "vx-y-z-25jxw5",
   "isPreProduction": false,
   "isProduction": true,
   "metadata": Object {
@@ -75,6 +77,7 @@ Object {
 
 exports[`should return the github global env 1`] = `
 Object {
+  "environment": "e2e-branch",
   "isPreProduction": false,
   "isProduction": false,
   "metadata": Object {
@@ -112,6 +115,7 @@ Object {
 
 exports[`should return the github global env with renovate prefixed env name 1`] = `
 Object {
+  "environment": "renovate-major-j-3qv5n7",
   "isPreProduction": false,
   "isProduction": false,
   "metadata": Object {
@@ -134,10 +138,10 @@ Object {
       "team": "sample-next-app",
     },
     "namespace": Object {
-      "name": "sample-next-app-renovatemajor-jest-monorepo",
+      "name": "sample-next-app-renovate-major-j-3qv5n7",
     },
     "rancherId": "c-bd7z2:p-7ms8p",
-    "subdomain": "sample-next-app-renovatemajor-jest-monorepo",
+    "subdomain": "sample-next-app-renovate-major-j-3qv5n7",
   },
   "projectName": "sample-next-app",
   "registry": "ghcr.io/socialgouv/sample-next-app",
@@ -149,6 +153,7 @@ Object {
 
 exports[`should return the github global env with slugify 1`] = `
 Object {
+  "environment": "domifa-commander-4k3z09",
   "isPreProduction": false,
   "isProduction": false,
   "metadata": Object {
@@ -171,10 +176,10 @@ Object {
       "team": "sample-next-app",
     },
     "namespace": Object {
-      "name": "sample-next-app-domifa-commander-8x",
+      "name": "sample-next-app-domifa-commander-4k3z09",
     },
     "rancherId": "c-bd7z2:p-7ms8p",
-    "subdomain": "sample-next-app-domifa-commander-8x",
+    "subdomain": "sample-next-app-domifa-commander-4k3z09",
   },
   "projectName": "sample-next-app",
   "registry": "ghcr.io/socialgouv/sample-next-app",

--- a/src/environments/github/index.ts
+++ b/src/environments/github/index.ts
@@ -1,6 +1,6 @@
 import type { CIEnv } from "@socialgouv/kosko-charts/types";
 import { assertEnv } from "@socialgouv/kosko-charts/utils/assertEnv";
-import slugify from "slugify";
+import { generate } from "@socialgouv/kosko-charts/utils/environmentSlug";
 
 const assert = assertEnv([
   "GITHUB_SHA",
@@ -43,9 +43,12 @@ export default (env = process.env): CIEnv => {
   const isProduction = Boolean(SOCIALGOUV_PRODUCTION);
   const isPreProduction = Boolean(SOCIALGOUV_PREPRODUCTION);
 
-  const branchName = GITHUB_REF.replace("refs/heads/", "");
+  const branchName = GITHUB_REF.replace("refs/heads/", "").replace(
+    "refs/tags/",
+    ""
+  );
 
-  const environmentSlug = slugify(branchName, { strict: true });
+  const environmentSlug = generate(branchName);
 
   const productionNamespace = projectName;
   const preProductionNamespace = `${projectName}-preprod`;
@@ -64,6 +67,7 @@ export default (env = process.env): CIEnv => {
     : devNamespace;
 
   return {
+    environment: environmentSlug,
     isPreProduction,
     isProduction,
     metadata: {

--- a/src/environments/gitlab/__snapshots__/index.test.ts.snap
+++ b/src/environments/gitlab/__snapshots__/index.test.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`should return production gitlab global env 1`] = `
 Object {
+  "environment": "my-test",
   "isPreProduction": false,
   "isProduction": true,
   "metadata": Object {
@@ -36,6 +37,7 @@ Object {
 
 exports[`should return tagged gitlab global env 1`] = `
 Object {
+  "environment": "my-test",
   "isPreProduction": false,
   "isProduction": false,
   "metadata": Object {
@@ -71,6 +73,7 @@ Object {
 
 exports[`should return the gitlab global env 1`] = `
 Object {
+  "environment": "my-test",
   "isPreProduction": false,
   "isProduction": false,
   "metadata": Object {
@@ -106,6 +109,7 @@ Object {
 
 exports[`should return the gitlab global env of the cluster dev2 1`] = `
 Object {
+  "environment": "my-test",
   "isPreProduction": false,
   "isProduction": false,
   "metadata": Object {

--- a/src/environments/gitlab/index.ts
+++ b/src/environments/gitlab/index.ts
@@ -57,6 +57,7 @@ export default (env = process.env): CIEnv => {
     : KUBE_NAMESPACE;
 
   return {
+    environment: CI_ENVIRONMENT_SLUG,
     isPreProduction,
     isProduction,
     metadata: {

--- a/src/environments/index.mock.ts
+++ b/src/environments/index.mock.ts
@@ -1,0 +1,26 @@
+import type { CIEnv } from "@socialgouv/kosko-charts/types";
+
+export default (): CIEnv => ({
+  environment: "my-test",
+  isPreProduction: false,
+  isProduction: false,
+  metadata: {
+    annotations: {
+      "app.gitlab.com/app": "socialgouv-sample",
+      "app.gitlab.com/env": "my-test",
+    },
+    domain: "domain",
+    git: {},
+    labels: {
+      application: "sample",
+      owner: "sample",
+      team: "sample",
+    },
+    namespace: { name: "sample-42-my-test" },
+    subdomain: "subdomain",
+  },
+  projectName: "sample",
+  registry: "registry",
+  sha: "0123456789abcdefghijklmnopqrstuvwxyz0123",
+  shortSha: "0123456",
+});

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -24,13 +24,13 @@ export interface NamedComponentEnvironment {
 }
 
 export interface CIEnv {
+  environment: string;
   isPreProduction: boolean;
   isProduction: boolean;
   metadata: GlobalEnvironment;
   projectName: string;
-  shortSha: string;
-
-  sha: string;
-  tag?: string;
   registry: string;
+  sha: string;
+  shortSha: string;
+  tag?: string;
 }

--- a/src/utils/environmentSlug.test.ts
+++ b/src/utils/environmentSlug.test.ts
@@ -2,48 +2,49 @@ import { generate } from "./environmentSlug";
 
 test.concurrent.each`
 name | expected
-${""} | ${"env-43gao4"}
+${""} | ${"env-5oaq0b"}
+${" "} | ${"env-1d1ppf"}
 ${"a"} | ${"a"}
-${"A"} | ${"a-51rzzs"}
+${"A"} | ${"a-24t5zj"}
 ${"foo"} | ${"foo"}
-${" foo"} | ${"foo-13m58g"}
-${"-foo"} | ${"foo-13m58g"}
-${".foo"} | ${"env-foo-30b7ar"}
-${"_foo"} | ${"env-foo-30b7ar"}
-${"/foo"} | ${"env-foo-30b7ar"}
-${"//foo"} | ${"env-foo-30b7ar"}
+${" foo"} | ${"foo-519jbe"}
+${"-foo"} | ${"foo-48rrcc"}
+${".foo"} | ${"env-foo-13scql"}
+${"_foo"} | ${"env-foo-276ax5"}
+${"/foo"} | ${"env-foo-2ry66a"}
+${"//foo"} | ${"env-foo-49jdu9"}
 ${"bar"} | ${"bar"}
-${"bar "} | ${"bar-6avzi6"}
-${"bar-"} | ${"bar-6avzi6"}
-${"bar."} | ${"bar-3p5jxr"}
-${"bar_"} | ${"bar-3p5jxr"}
-${"bar//"} | ${"bar-3p5jxr"}
-${"42"} | ${"env-42-69um1o"}
-${"42-foo"} | ${"env-42-foo-1wgih0"}
-${"42-foo/bar-42"} | ${"env-42-foo-bar-4-3k4xn2"}
-${"foo bar"} | ${"foo-bar-34n246"}
-${"foo  bar"} | ${"foo-bar-34n246"}
-${"foo - bar"} | ${"foo-bar-34n246"}
-${"foo -bar"} | ${"foo-bar-34n246"}
-${"foo- bar"} | ${"foo-bar-34n246"}
+${"bar "} | ${"bar-3bd9i7"}
+${"bar-"} | ${"bar-3p5jxr"}
+${"bar."} | ${"bar-3odd94"}
+${"bar_"} | ${"bar-3zwwso"}
+${"bar//"} | ${"bar-51rfpg"}
+${"42"} | ${"env-42-2vfnyo"}
+${"42-foo"} | ${"env-42-foo-2rkzi7"}
+${"42-foo/bar-42"} | ${"env-42-foo-bar-4-47yjnm"}
+${"foo bar"} | ${"foo-bar-69w36b"}
+${"foo  bar"} | ${"foo-bar-3dj5tm"}
+${"foo - bar"} | ${"foo-bar-21zv3j"}
+${"foo -bar"} | ${"foo-bar-ftlsyn"}
+${"foo- bar"} | ${"foo-bar-202h7o"}
 ${"foo-bar"} | ${"foo-bar"}
-${"foo_bar"} | ${"foo-bar-34n246"}
-${"foo/bar"} | ${"foo-bar-34n246"}
-${"foo~bar"} | ${"foo-bar-34n246"}
-${"foo@bar"} | ${"foo-bar-34n246"}
+${"foo_bar"} | ${"foo-bar-1tn5ds"}
+${"foo/bar"} | ${"foo-bar-53d979"}
+${"foo~bar"} | ${"foo-bar-63gi2v"}
+${"foo@bar"} | ${"foo-bar-5v88ns"}
 ...
 ${"master"} | ${"master"}
 ${"alpha"} | ${"alpha"}
 ${"beta"} | ${"beta"}
 ${"next"} | ${"next"}
-${"v0.0.0"} | ${"v0-0-0-3juiz4"}
-${"v0.0.1"} | ${"v0-0-1-53ptvv"}
-${"v0.1.1"} | ${"v0-1-1-1g556e"}
-${"v1.1.1"} | ${"v1-1-1-55k9zo"}
+${"v0.0.0"} | ${"v0-0-0-4svh1v"}
+${"v0.0.1"} | ${"v0-0-1-4cg10t"}
+${"v0.1.1"} | ${"v0-1-1-21ni6m"}
+${"v1.1.1"} | ${"v1-1-1-3k7de0"}
 ...
-${"renovate/socialgouvdocker-images"} | ${"renovate-socialg-1colh5"}
+${"renovate/socialgouvdocker-images"} | ${"renovate-socialg-1e66b4"}
 `(
-  "returns $expected env slug for branch $name",
+  "'$name' 's slug should be '$expected'",
   ({ name, expected }: { name: string; expected: string }) => {
     expect(generate(name)).toBe(expected);
   }

--- a/src/utils/environmentSlug.ts
+++ b/src/utils/environmentSlug.ts
@@ -16,13 +16,6 @@ export function generate(name: string): string {
   let slugified = slugify(name, {
     lower: true,
   });
-  // see https://gist.github.com/codeguy/6684588#gistcomment-3361909
-  // .normalize("NFD") // split an accented letter in the base letter and the acent
-  // .replace(/[\u0300-\u036f]/g, "") // remove all previously split accents
-  // .toLowerCase()
-  // .trim()
-  // .replace(/[^a-z0-9 ]/g, "-") // remove all chars not letters, numbers and spaces (to be replaced)
-  // .replace(/\s+/g, "-"); // separator
 
   // Must start with a letter
   if (!/^[a-z]/.exec(slugified)) slugified = "env-" + slugified;
@@ -31,10 +24,14 @@ export function generate(name: string): string {
   slugified = slugified.replace(/-{2,}/g, "-");
 
   // Repeated dashes are invalid (OpenShift limitation)
-  slugified =
-    slugified.length > 24 || slugified != name
-      ? shortenAndAddSuffix(slugified)
-      : slugified.replace(/-$/, "");
+  if (slugified.length > 24 || slugified !== name) {
+    const shortSlug = slugified.slice(0, 16);
+    slugified = `${shortSlug}${shortSlug.endsWith("-") ? "" : "-"}${suffix(
+      name
+    )}`;
+  }
+
+  slugified = slugified.replace(/-{2,}/g, "-");
 
   return slugified;
 }

--- a/templates/hasura/components/pg.ts
+++ b/templates/hasura/components/pg.ts
@@ -1,32 +1,6 @@
 import env from "@kosko/env";
-import type { SealedSecret } from "@kubernetes-models/sealed-secrets/bitnami.com/v1alpha1/SealedSecret";
 import { create } from "@socialgouv/kosko-charts/components/azure-pg";
-import environments from "@socialgouv/kosko-charts/environments";
-import { loadYaml } from "@socialgouv/kosko-charts/utils/getEnvironmentComponent";
-import { updateMetadata } from "@socialgouv/kosko-charts/utils/updateMetadata";
 
-export default async (): Promise<{ kind: string }[]> => {
-  if (env.env === "dev") {
-    return create({
-      env,
-    });
-  }
-
-  // in prod/preprod, we try to add a fixed sealed-secret
-  const secret = await loadYaml<SealedSecret>(
-    env,
-    `pg-user.sealed-secret.yaml`
-  );
-  if (!secret) {
-    return [];
-  }
-
-  const envParams = environments(process.env);
-  // add gitlab annotations
-  updateMetadata(secret, {
-    annotations: envParams.metadata.annotations ?? {},
-    labels: envParams.metadata.labels ?? {},
-    namespace: envParams.metadata.namespace,
-  });
-  return [secret];
-};
+export default create("pg-user", {
+  env,
+});

--- a/templates/hasura/package.json
+++ b/templates/hasura/package.json
@@ -4,7 +4,7 @@
     "kubernetes-models": "^1.7.1"
   },
   "devDependencies": {
-    "@socialgouv/kosko-charts": "^8.1.1",
+    "@socialgouv/kosko-charts": "^9.0.0-beta.1",
     "@types/node": "^14.17.6",
     "dotenv": "^10.0.0",
     "kosko": "^1.1.5",

--- a/templates/nginx/package.json
+++ b/templates/nginx/package.json
@@ -4,7 +4,7 @@
     "kubernetes-models": "^1.7.1"
   },
   "devDependencies": {
-    "@socialgouv/kosko-charts": "^8.1.1",
+    "@socialgouv/kosko-charts": "^9.0.0-beta.1",
     "@types/node": "^14.17.6",
     "dotenv": "^10.0.0",
     "kosko": "^1.1.5",

--- a/templates/pgweb/components/pg.ts
+++ b/templates/pgweb/components/pg.ts
@@ -1,32 +1,6 @@
 import env from "@kosko/env";
-import type { SealedSecret } from "@kubernetes-models/sealed-secrets/bitnami.com/v1alpha1/SealedSecret";
 import { create } from "@socialgouv/kosko-charts/components/azure-pg";
-import environments from "@socialgouv/kosko-charts/environments";
-import { loadYaml } from "@socialgouv/kosko-charts/utils/getEnvironmentComponent";
-import { updateMetadata } from "@socialgouv/kosko-charts/utils/updateMetadata";
 
-export default async (): Promise<{ kind: string }[]> => {
-  if (env.env === "dev") {
-    return create({
-      env,
-    });
-  }
-
-  // in prod/preprod, we try to add a fixed sealed-secret
-  const secret = await loadYaml<SealedSecret>(
-    env,
-    `pg-user.sealed-secret.yaml`
-  );
-  if (!secret) {
-    return [];
-  }
-
-  const envParams = environments(process.env);
-  // add gitlab annotations
-  updateMetadata(secret, {
-    annotations: envParams.metadata.annotations ?? {},
-    labels: envParams.metadata.labels ?? {},
-    namespace: envParams.metadata.namespace,
-  });
-  return [secret];
-};
+export default create("pg-user", {
+  env,
+});

--- a/templates/pgweb/package.json
+++ b/templates/pgweb/package.json
@@ -4,7 +4,7 @@
     "kubernetes-models": "^1.7.1"
   },
   "devDependencies": {
-    "@socialgouv/kosko-charts": "^8.1.1",
+    "@socialgouv/kosko-charts": "^9.0.0-beta.1",
     "@types/node": "^14.17.6",
     "dotenv": "^10.0.0",
     "kosko": "^1.1.5",

--- a/templates/redis/package.json
+++ b/templates/redis/package.json
@@ -4,7 +4,7 @@
     "kubernetes-models": "^1.7.1"
   },
   "devDependencies": {
-    "@socialgouv/kosko-charts": "^8.1.1",
+    "@socialgouv/kosko-charts": "^9.0.0-beta.1",
     "@types/node": "^14.17.6",
     "dotenv": "^10.0.0",
     "kosko": "^1.1.5",

--- a/templates/sample/components/pg.ts
+++ b/templates/sample/components/pg.ts
@@ -1,32 +1,6 @@
 import env from "@kosko/env";
-import type { SealedSecret } from "@kubernetes-models/sealed-secrets/bitnami.com/v1alpha1/SealedSecret";
 import { create } from "@socialgouv/kosko-charts/components/azure-pg";
-import environments from "@socialgouv/kosko-charts/environments";
-import { loadYaml } from "@socialgouv/kosko-charts/utils/getEnvironmentComponent";
-import { updateMetadata } from "@socialgouv/kosko-charts/utils/updateMetadata";
 
-export default async (): Promise<{ kind: string }[]> => {
-  if (env.env === "dev") {
-    return create({
-      env,
-    });
-  }
-
-  // in prod/preprod, we try to add a fixed sealed-secret
-  const secret = await loadYaml<SealedSecret>(
-    env,
-    `pg-user.sealed-secret.yaml`
-  );
-  if (!secret) {
-    return [];
-  }
-
-  const envParams = environments(process.env);
-  // add gitlab annotations
-  updateMetadata(secret, {
-    annotations: envParams.metadata.annotations ?? {},
-    labels: envParams.metadata.labels ?? {},
-    namespace: envParams.metadata.namespace,
-  });
-  return [secret];
-};
+export default create("pg-user", {
+  env,
+});

--- a/templates/sample/package.json
+++ b/templates/sample/package.json
@@ -4,7 +4,7 @@
     "kubernetes-models": "^1.7.1"
   },
   "devDependencies": {
-    "@socialgouv/kosko-charts": "^8.1.1",
+    "@socialgouv/kosko-charts": "^9.0.0-beta.1",
     "@types/node": "^14.17.6",
     "dotenv": "^10.0.0",
     "kosko": "^1.1.5",

--- a/templates/testing/package.json
+++ b/templates/testing/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@kosko/env": "^2.0.1",
     "@kubernetes-models/sealed-secrets": "^1.6.3",
-    "@socialgouv/kosko-charts": "^8.1.1",
+    "@socialgouv/kosko-charts": "^9.0.0-beta.1",
     "@types/node": "^14.17.6",
     "kosko": "^1.1.5",
     "kubernetes-models": "^1.7.1",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -8,5 +8,5 @@
     "sourceMap": true
   },
   "include": ["src"],
-  "exclude": ["**/*.test.ts"]
+  "exclude": ["**/*.test.ts", "**/*.mock.ts"]
 }


### PR DESCRIPTION
<img width=100% src=https://media.giphy.com/media/xT9KVy0y4TpSKBr6BW/giphy.gif />

---

BREAKING CHANGE: Our create database component is now creating one database per branch

Previously our `@socialgouv/kosko-charts/components/azure-pg` component was creating one database per commit. As it happen to be a rare need at @SocialGouv, we now switch to one database per branch.


BREAKING CHANGE: Unify commen `pg.ts` component use under the same function

Previously our `@socialgouv/kosko-charts/components/azure-pg` component was only handling the "dev"/"review" use case where we have to create the database and the user ourself. This ends up putting on the user land the responsibility of manually loading a sealedsecret in other case. As it happen to be a common need at @SocialGouv, we now deal with loading the file our creating the database as before if the named file does not exist.

```diff
import env from "@kosko/env";
-import type { SealedSecret } from "@kubernetes-models/sealed-secrets/bitnami.com/v1alpha1/SealedSecret";
 import { create } from "@socialgouv/kosko-charts/components/azure-pg";
-import environments from "@socialgouv/kosko-charts/environments";
-import { loadYaml } from "@socialgouv/kosko-charts/utils/getEnvironmentComponent";
-import { updateMetadata } from "@socialgouv/kosko-charts/utils/updateMetadata";

+export default create("pg-user", {
+  env,
+});
-export default async (): Promise<{ kind: string }[]> => {
-  if (env.env === "dev") {
-    return create({
-      env,
-    });
-  }
-
-  // in prod/preprod, we try to add a fixed sealed-secret
-  const secret = await loadYaml<SealedSecret>(
-    env,
-    `pg-user.sealed-secret.yaml`
-  );
-  if (!secret) {
-    return [];
-  }
-
-  const envParams = environments(process.env);
-  // add gitlab annotations
-  updateMetadata(secret, {
-    annotations: envParams.metadata.annotations ?? {},
-    labels: envParams.metadata.labels ?? {},
-    namespace: envParams.metadata.namespace,
-  });
-  return [secret];
-};
```

The new `create` function of `@socialgouv/kosko-charts/components/azure-pg` takes a `name` as fist argument used to "guest" the file to load `${name}.sealed-secret.yaml` is the given env (as before)