### PR TITLE
feat(components): add janitor annotations in dev

### DIFF
--- a/e2e/kitchen-sink/__tests__/__snapshots__/multihost.ts.snap
+++ b/e2e/kitchen-sink/__tests__/__snapshots__/multihost.ts.snap
@@ -6,6 +6,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   annotations:
+    socialgouv/creator: autodevops
+    janitor/ttl: 15d
     field.cattle.io/creatorId: gitlab
     field.cattle.io/projectId: c-bd7z2:p-7ms8p
     git/branch: e2e-branch

--- a/e2e/templates/hasura/kosko generate/__tests__/__snapshots__/--env dev github.ts.snap
+++ b/e2e/templates/hasura/kosko generate/__tests__/__snapshots__/--env dev github.ts.snap
@@ -6,6 +6,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   annotations:
+    socialgouv/creator: autodevops
+    janitor/ttl: 15d
     field.cattle.io/creatorId: gitlab
     field.cattle.io/projectId: c-bd7z2:p-7ms8p
     git/branch: refs/heads/e2e-branch

--- a/e2e/templates/hasura/kosko generate/__tests__/__snapshots__/--env dev.ts.snap
+++ b/e2e/templates/hasura/kosko generate/__tests__/__snapshots__/--env dev.ts.snap
@@ -6,6 +6,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   annotations:
+    socialgouv/creator: autodevops
+    janitor/ttl: 15d
     field.cattle.io/creatorId: gitlab
     field.cattle.io/projectId: c-bd7z2:p-7ms8p
     git/branch: e2e-branch

--- a/e2e/templates/hasura/kosko generate/__tests__/__snapshots__/--env preprod github.ts.snap
+++ b/e2e/templates/hasura/kosko generate/__tests__/__snapshots__/--env preprod github.ts.snap
@@ -6,6 +6,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   annotations:
+    socialgouv/creator: autodevops
     field.cattle.io/creatorId: gitlab
     field.cattle.io/projectId: c-bd7z2:p-7ms8p
     git/branch: refs/heads/e2e-branch

--- a/e2e/templates/hasura/kosko generate/__tests__/__snapshots__/--env preprod.ts.snap
+++ b/e2e/templates/hasura/kosko generate/__tests__/__snapshots__/--env preprod.ts.snap
@@ -6,6 +6,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   annotations:
+    socialgouv/creator: autodevops
     field.cattle.io/creatorId: gitlab
     field.cattle.io/projectId: c-bd7z2:p-7ms8p
     git/branch: e2e-branch

--- a/e2e/templates/nginx/kosko generate/__tests__/__snapshots__/--env dev github.ts.snap
+++ b/e2e/templates/nginx/kosko generate/__tests__/__snapshots__/--env dev github.ts.snap
@@ -6,6 +6,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   annotations:
+    socialgouv/creator: autodevops
+    janitor/ttl: 15d
     field.cattle.io/creatorId: gitlab
     field.cattle.io/projectId: c-bd7z2:p-7ms8p
     git/branch: refs/heads/e2e-branch

--- a/e2e/templates/nginx/kosko generate/__tests__/__snapshots__/--env dev.ts.snap
+++ b/e2e/templates/nginx/kosko generate/__tests__/__snapshots__/--env dev.ts.snap
@@ -6,6 +6,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   annotations:
+    socialgouv/creator: autodevops
+    janitor/ttl: 15d
     field.cattle.io/creatorId: gitlab
     field.cattle.io/projectId: c-bd7z2:p-7ms8p
     git/branch: e2e-branch

--- a/e2e/templates/nginx/kosko generate/__tests__/__snapshots__/--env preprod github.ts.snap
+++ b/e2e/templates/nginx/kosko generate/__tests__/__snapshots__/--env preprod github.ts.snap
@@ -6,6 +6,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   annotations:
+    socialgouv/creator: autodevops
     field.cattle.io/creatorId: gitlab
     field.cattle.io/projectId: c-bd7z2:p-7ms8p
     git/branch: refs/heads/e2e-branch

--- a/e2e/templates/nginx/kosko generate/__tests__/__snapshots__/--env preprod.ts.snap
+++ b/e2e/templates/nginx/kosko generate/__tests__/__snapshots__/--env preprod.ts.snap
@@ -6,6 +6,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   annotations:
+    socialgouv/creator: autodevops
     field.cattle.io/creatorId: gitlab
     field.cattle.io/projectId: c-bd7z2:p-7ms8p
     git/branch: e2e-branch

--- a/e2e/templates/pgweb/kosko generate/__tests__/__snapshots__/--env dev github.ts.snap
+++ b/e2e/templates/pgweb/kosko generate/__tests__/__snapshots__/--env dev github.ts.snap
@@ -6,6 +6,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   annotations:
+    socialgouv/creator: autodevops
+    janitor/ttl: 15d
     field.cattle.io/creatorId: gitlab
     field.cattle.io/projectId: c-bd7z2:p-7ms8p
     git/branch: refs/heads/e2e-branch

--- a/e2e/templates/pgweb/kosko generate/__tests__/__snapshots__/--env dev.ts.snap
+++ b/e2e/templates/pgweb/kosko generate/__tests__/__snapshots__/--env dev.ts.snap
@@ -6,6 +6,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   annotations:
+    socialgouv/creator: autodevops
+    janitor/ttl: 15d
     field.cattle.io/creatorId: gitlab
     field.cattle.io/projectId: c-bd7z2:p-7ms8p
     git/branch: e2e-branch

--- a/e2e/templates/pgweb/kosko generate/__tests__/__snapshots__/--env preprod github.ts.snap
+++ b/e2e/templates/pgweb/kosko generate/__tests__/__snapshots__/--env preprod github.ts.snap
@@ -6,6 +6,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   annotations:
+    socialgouv/creator: autodevops
     field.cattle.io/creatorId: gitlab
     field.cattle.io/projectId: c-bd7z2:p-7ms8p
     git/branch: refs/heads/e2e-branch

--- a/e2e/templates/pgweb/kosko generate/__tests__/__snapshots__/--env preprod.ts.snap
+++ b/e2e/templates/pgweb/kosko generate/__tests__/__snapshots__/--env preprod.ts.snap
@@ -6,6 +6,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   annotations:
+    socialgouv/creator: autodevops
     field.cattle.io/creatorId: gitlab
     field.cattle.io/projectId: c-bd7z2:p-7ms8p
     git/branch: e2e-branch

--- a/e2e/templates/redis/kosko generate/__tests__/__snapshots__/--env dev github.ts.snap
+++ b/e2e/templates/redis/kosko generate/__tests__/__snapshots__/--env dev github.ts.snap
@@ -6,6 +6,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   annotations:
+    socialgouv/creator: autodevops
+    janitor/ttl: 15d
     field.cattle.io/creatorId: gitlab
     field.cattle.io/projectId: c-bd7z2:p-7ms8p
     git/branch: refs/heads/e2e-branch

--- a/e2e/templates/redis/kosko generate/__tests__/__snapshots__/--env dev.ts.snap
+++ b/e2e/templates/redis/kosko generate/__tests__/__snapshots__/--env dev.ts.snap
@@ -6,6 +6,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   annotations:
+    socialgouv/creator: autodevops
+    janitor/ttl: 15d
     field.cattle.io/creatorId: gitlab
     field.cattle.io/projectId: c-bd7z2:p-7ms8p
     git/branch: e2e-branch

--- a/e2e/templates/redis/kosko generate/__tests__/__snapshots__/--env preprod github.ts.snap
+++ b/e2e/templates/redis/kosko generate/__tests__/__snapshots__/--env preprod github.ts.snap
@@ -6,6 +6,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   annotations:
+    socialgouv/creator: autodevops
     field.cattle.io/creatorId: gitlab
     field.cattle.io/projectId: c-bd7z2:p-7ms8p
     git/branch: refs/heads/e2e-branch

--- a/e2e/templates/redis/kosko generate/__tests__/__snapshots__/--env preprod.ts.snap
+++ b/e2e/templates/redis/kosko generate/__tests__/__snapshots__/--env preprod.ts.snap
@@ -6,6 +6,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   annotations:
+    socialgouv/creator: autodevops
     field.cattle.io/creatorId: gitlab
     field.cattle.io/projectId: c-bd7z2:p-7ms8p
     git/branch: e2e-branch

--- a/e2e/templates/sample/kosko generate/__tests__/__snapshots__/--env dev github.ts.snap
+++ b/e2e/templates/sample/kosko generate/__tests__/__snapshots__/--env dev github.ts.snap
@@ -6,6 +6,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   annotations:
+    socialgouv/creator: autodevops
+    janitor/ttl: 15d
     field.cattle.io/creatorId: gitlab
     field.cattle.io/projectId: c-bd7z2:p-7ms8p
     git/branch: refs/heads/e2e-branch

--- a/e2e/templates/sample/kosko generate/__tests__/__snapshots__/--env dev.ts.snap
+++ b/e2e/templates/sample/kosko generate/__tests__/__snapshots__/--env dev.ts.snap
@@ -6,6 +6,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   annotations:
+    socialgouv/creator: autodevops
+    janitor/ttl: 15d
     field.cattle.io/creatorId: gitlab
     field.cattle.io/projectId: c-bd7z2:p-7ms8p
     git/branch: e2e-branch

--- a/e2e/templates/sample/kosko generate/__tests__/__snapshots__/--env preprod github.ts.snap
+++ b/e2e/templates/sample/kosko generate/__tests__/__snapshots__/--env preprod github.ts.snap
@@ -6,6 +6,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   annotations:
+    socialgouv/creator: autodevops
     field.cattle.io/creatorId: gitlab
     field.cattle.io/projectId: c-bd7z2:p-7ms8p
     git/branch: refs/heads/e2e-branch

--- a/e2e/templates/sample/kosko generate/__tests__/__snapshots__/--env preprod.ts.snap
+++ b/e2e/templates/sample/kosko generate/__tests__/__snapshots__/--env preprod.ts.snap
@@ -6,6 +6,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   annotations:
+    socialgouv/creator: autodevops
     field.cattle.io/creatorId: gitlab
     field.cattle.io/projectId: c-bd7z2:p-7ms8p
     git/branch: e2e-branch

--- a/e2e/testing/__fixtures__/__tests__/__snapshots__/kosko generate --env dev.ts.snap
+++ b/e2e/testing/__fixtures__/__tests__/__snapshots__/kosko generate --env dev.ts.snap
@@ -6,6 +6,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   annotations:
+    socialgouv/creator: autodevops
+    janitor/ttl: 15d
     field.cattle.io/creatorId: gitlab
     field.cattle.io/projectId: c-bd7z2:p-7ms8p
     git/branch: master

--- a/e2e/testing/__fixtures__/__tests__/__snapshots__/kosko generate --env preprod.ts.snap
+++ b/e2e/testing/__fixtures__/__tests__/__snapshots__/kosko generate --env preprod.ts.snap
@@ -6,6 +6,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   annotations:
+    socialgouv/creator: autodevops
     field.cattle.io/creatorId: gitlab
     field.cattle.io/projectId: c-bd7z2:p-7ms8p
     git/branch: v1.2.3

--- a/src/components/namespace/__snapshots__/index.test.ts.snap
+++ b/src/components/namespace/__snapshots__/index.test.ts.snap
@@ -10,6 +10,8 @@ Object {
       "field.cattle.io/projectId": "",
       "git/branch": "",
       "git/remote": "",
+      "janitor/ttl": "15d",
+      "socialgouv/creator": "autodevops",
     },
     "labels": Object {},
     "name": "sample-42-my-test",
@@ -29,6 +31,8 @@ Object {
       "field.cattle.io/projectId": "rancherId",
       "git/branch": "my-branch",
       "git/remote": "my-origin",
+      "janitor/ttl": "15d",
+      "socialgouv/creator": "autodevops",
     },
     "labels": Object {
       "application": "sample",

--- a/src/components/namespace/index.test.ts
+++ b/src/components/namespace/index.test.ts
@@ -1,6 +1,8 @@
 //
 
 const gitlabMock = {
+  isPreProduction: false,
+  isProduction: false,
   metadata: {
     git: {},
     namespace: { name: "sample-42-my-test" },
@@ -54,4 +56,63 @@ test("should create a namespace with extra labels and annotations", async () => 
   const { createNamespace } = await import("./index");
   const namespace = createNamespace();
   expect(namespace).toMatchSnapshot();
+  expect(
+    namespace.metadata &&
+      namespace.metadata.annotations &&
+      namespace.metadata.annotations["janitor/ttl"]
+  ).toEqual("15d");
+});
+
+test("should NOT add janitor annotation if keepAlive set to true", async () => {
+  Object.assign(gitlabMock, {
+    isPreProduction: false,
+    isProduction: false,
+  });
+  jest.doMock(
+    "@socialgouv/kosko-charts/environments/gitlab",
+    () => gitlabModuleMock
+  );
+  const { createNamespace } = await import("./index");
+  const namespace = createNamespace({ keepAlive: true });
+  expect(
+    namespace.metadata &&
+      namespace.metadata.annotations &&
+      namespace.metadata.annotations["janitor/ttl"]
+  ).toBeUndefined();
+});
+
+test("should NOT add janitor annotation for preprod", async () => {
+  Object.assign(gitlabMock, {
+    isPreProduction: true,
+    isProduction: false,
+  });
+  jest.doMock(
+    "@socialgouv/kosko-charts/environments/gitlab",
+    () => gitlabModuleMock
+  );
+  const { createNamespace } = await import("./index");
+  const namespace = createNamespace();
+  expect(
+    namespace.metadata &&
+      namespace.metadata.annotations &&
+      namespace.metadata.annotations["janitor/ttl"]
+  ).toBeUndefined();
+});
+
+test("should NOT add janitor annotation for prod", async () => {
+  Object.assign(gitlabMock, {
+    isPreProduction: false,
+    isProduction: true,
+  });
+  jest.doMock(
+    "@socialgouv/kosko-charts/environments/gitlab",
+    () => gitlabModuleMock
+  );
+  const { createNamespace } = await import("./index");
+  const namespace = createNamespace();
+  expect(
+    namespace.metadata &&
+      namespace.metadata.annotations &&
+      namespace.metadata.annotations["janitor/ttl"]
+  ).toBeUndefined();
 });

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -9,6 +9,7 @@ export interface NamespaceComponentEnvironment extends MetadataEntries {
   namespace: { name: string };
   rancherId?: string;
   git: { branch?: string; remote?: string };
+  keepAlive?: boolean;
 }
 
 export interface GlobalEnvironment extends NamespaceComponentEnvironment {


### PR DESCRIPTION

 - adds a `socialgouv/creator: autodevops` annotation on all namespaces
 - `janitor/ttl: 15d` is added for dev envs only
 - `createNamespace` can receive a `keepAlive` that disable this behaviour

with this, all dev namespaces will be destroyed after 15 days