### PR TITLE
fix(autodevops): dont include namespaces in prod

### DIFF
--- a/e2e/templates/autodevops/app-ingress-anotations/__tests__/__snapshots__/kosko generate --env prod.ts.snap
+++ b/e2e/templates/autodevops/app-ingress-anotations/__tests__/__snapshots__/kosko generate --env prod.ts.snap
@@ -2,27 +2,6 @@
 
 exports[`app-ingress-annotations: kosko generate --prod 1`] = `
 "---
-apiVersion: v1
-kind: Namespace
-metadata:
-  annotations:
-    socialgouv/creator: autodevops
-    janitor/ttl: 15d
-    field.cattle.io/creatorId: gitlab
-    field.cattle.io/projectId: c-bd7z2:p-7ms8p
-    git/branch: e2e-branch
-    git/remote: git@github.com:SocialGouv/sample-kosko.git
-    app.gitlab.com/app: socialgouv-sample-kosko
-    app.gitlab.com/env: e2e-branch-42
-    app.gitlab.com/env.name: e2e-branch-dev2
-  labels:
-    azure-pg-admin-user: sample-kosko
-    application: e2e-branch-42-sample-kosko
-    owner: sample-kosko
-    team: sample-kosko
-    cert: wildcard
-  name: sample-kosko-24-e2e-branch-42
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/e2e/templates/autodevops/app/__tests__/__snapshots__/kosko generate --env prod.ts.snap
+++ b/e2e/templates/autodevops/app/__tests__/__snapshots__/kosko generate --env prod.ts.snap
@@ -2,27 +2,6 @@
 
 exports[`app: kosko generate --prod 1`] = `
 "---
-apiVersion: v1
-kind: Namespace
-metadata:
-  annotations:
-    socialgouv/creator: autodevops
-    janitor/ttl: 15d
-    field.cattle.io/creatorId: gitlab
-    field.cattle.io/projectId: c-bd7z2:p-7ms8p
-    git/branch: e2e-branch
-    git/remote: git@github.com:SocialGouv/sample-kosko.git
-    app.gitlab.com/app: socialgouv-sample-kosko
-    app.gitlab.com/env: e2e-branch-42
-    app.gitlab.com/env.name: e2e-branch-dev2
-  labels:
-    azure-pg-admin-user: sample-kosko
-    application: e2e-branch-42-sample-kosko
-    owner: sample-kosko
-    team: sample-kosko
-    cert: wildcard
-  name: sample-kosko-24-e2e-branch-42
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/e2e/templates/autodevops/azurepg/__tests__/__snapshots__/kosko generate --env prod.ts.snap
+++ b/e2e/templates/autodevops/azurepg/__tests__/__snapshots__/kosko generate --env prod.ts.snap
@@ -2,26 +2,6 @@
 
 exports[`azurepg: kosko generate --prod 1`] = `
 "---
-apiVersion: v1
-kind: Namespace
-metadata:
-  annotations:
-    socialgouv/creator: autodevops
-    field.cattle.io/creatorId: gitlab
-    field.cattle.io/projectId: c-bd7z2:p-7ms8p
-    git/branch: e2e-branch
-    git/remote: git@github.com:SocialGouv/sample-kosko.git
-    app.gitlab.com/app: socialgouv-sample-kosko
-    app.gitlab.com/env: e2e-branch-42
-    app.gitlab.com/env.name: e2e-branch-dev2
-  labels:
-    azure-pg-admin-user: sample-kosko
-    application: sample-kosko
-    owner: sample-kosko
-    team: sample-kosko
-    cert: wildcard
-  name: sample-kosko
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/e2e/templates/autodevops/hasura/__tests__/__snapshots__/kosko generate --env prod.ts.snap
+++ b/e2e/templates/autodevops/hasura/__tests__/__snapshots__/kosko generate --env prod.ts.snap
@@ -2,27 +2,6 @@
 
 exports[`hasura with ingress: kosko generate --prod 1`] = `
 "---
-apiVersion: v1
-kind: Namespace
-metadata:
-  annotations:
-    socialgouv/creator: autodevops
-    janitor/ttl: 15d
-    field.cattle.io/creatorId: gitlab
-    field.cattle.io/projectId: c-bd7z2:p-7ms8p
-    git/branch: e2e-branch
-    git/remote: git@github.com:SocialGouv/sample-kosko.git
-    app.gitlab.com/app: socialgouv-sample-kosko
-    app.gitlab.com/env: e2e-branch-42
-    app.gitlab.com/env.name: e2e-branch-dev2
-  labels:
-    azure-pg-admin-user: sample-kosko
-    application: e2e-branch-42-sample-kosko
-    owner: sample-kosko
-    team: sample-kosko
-    cert: wildcard
-  name: sample-kosko-24-e2e-branch-42
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -321,27 +300,6 @@ spec:
 
 exports[`hasura: kosko generate --prod 1`] = `
 "---
-apiVersion: v1
-kind: Namespace
-metadata:
-  annotations:
-    socialgouv/creator: autodevops
-    janitor/ttl: 15d
-    field.cattle.io/creatorId: gitlab
-    field.cattle.io/projectId: c-bd7z2:p-7ms8p
-    git/branch: e2e-branch
-    git/remote: git@github.com:SocialGouv/sample-kosko.git
-    app.gitlab.com/app: socialgouv-sample-kosko
-    app.gitlab.com/env: e2e-branch-42
-    app.gitlab.com/env.name: e2e-branch-dev2
-  labels:
-    azure-pg-admin-user: sample-kosko
-    application: e2e-branch-42-sample-kosko
-    owner: sample-kosko
-    team: sample-kosko
-    cert: wildcard
-  name: sample-kosko-24-e2e-branch-42
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/e2e/templates/autodevops/probes/__tests__/__snapshots__/kosko generate --env prod.ts.snap
+++ b/e2e/templates/autodevops/probes/__tests__/__snapshots__/kosko generate --env prod.ts.snap
@@ -2,27 +2,6 @@
 
 exports[`probes: kosko generate --prod 1`] = `
 "---
-apiVersion: v1
-kind: Namespace
-metadata:
-  annotations:
-    socialgouv/creator: autodevops
-    janitor/ttl: 15d
-    field.cattle.io/creatorId: gitlab
-    field.cattle.io/projectId: c-bd7z2:p-7ms8p
-    git/branch: e2e-branch
-    git/remote: git@github.com:SocialGouv/sample-kosko.git
-    app.gitlab.com/app: socialgouv-sample-kosko
-    app.gitlab.com/env: e2e-branch-42
-    app.gitlab.com/env.name: e2e-branch-dev2
-  labels:
-    azure-pg-admin-user: sample-kosko
-    application: e2e-branch-42-sample-kosko
-    owner: sample-kosko
-    team: sample-kosko
-    cert: wildcard
-  name: sample-kosko-24-e2e-branch-42
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/e2e/templates/autodevops/probesPath/__tests__/__snapshots__/kosko generate --env prod.ts.snap
+++ b/e2e/templates/autodevops/probesPath/__tests__/__snapshots__/kosko generate --env prod.ts.snap
@@ -2,27 +2,6 @@
 
 exports[`probesPath: kosko generate --prod 1`] = `
 "---
-apiVersion: v1
-kind: Namespace
-metadata:
-  annotations:
-    socialgouv/creator: autodevops
-    janitor/ttl: 15d
-    field.cattle.io/creatorId: gitlab
-    field.cattle.io/projectId: c-bd7z2:p-7ms8p
-    git/branch: e2e-branch
-    git/remote: git@github.com:SocialGouv/sample-kosko.git
-    app.gitlab.com/app: socialgouv-sample-kosko
-    app.gitlab.com/env: e2e-branch-42
-    app.gitlab.com/env.name: e2e-branch-dev2
-  labels:
-    azure-pg-admin-user: sample-kosko
-    application: e2e-branch-42-sample-kosko
-    owner: sample-kosko
-    team: sample-kosko
-    cert: wildcard
-  name: sample-kosko-24-e2e-branch-42
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/e2e/templates/autodevops/registry/__tests__/__snapshots__/kosko generate --env prod.ts.snap
+++ b/e2e/templates/autodevops/registry/__tests__/__snapshots__/kosko generate --env prod.ts.snap
@@ -2,27 +2,6 @@
 
 exports[`registry: kosko generate --prod 1`] = `
 "---
-apiVersion: v1
-kind: Namespace
-metadata:
-  annotations:
-    socialgouv/creator: autodevops
-    janitor/ttl: 15d
-    field.cattle.io/creatorId: gitlab
-    field.cattle.io/projectId: c-bd7z2:p-7ms8p
-    git/branch: e2e-branch
-    git/remote: git@github.com:SocialGouv/sample-kosko.git
-    app.gitlab.com/app: socialgouv-sample-kosko
-    app.gitlab.com/env: e2e-branch-42
-    app.gitlab.com/env.name: e2e-branch-dev2
-  labels:
-    azure-pg-admin-user: sample-kosko
-    application: e2e-branch-42-sample-kosko
-    owner: sample-kosko
-    team: sample-kosko
-    cert: wildcard
-  name: sample-kosko-24-e2e-branch-42
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/e2e/templates/autodevops/resources/__tests__/__snapshots__/kosko generate --env prod.ts.snap
+++ b/e2e/templates/autodevops/resources/__tests__/__snapshots__/kosko generate --env prod.ts.snap
@@ -2,27 +2,6 @@
 
 exports[`resources: kosko generate --prod 1`] = `
 "---
-apiVersion: v1
-kind: Namespace
-metadata:
-  annotations:
-    socialgouv/creator: autodevops
-    janitor/ttl: 15d
-    field.cattle.io/creatorId: gitlab
-    field.cattle.io/projectId: c-bd7z2:p-7ms8p
-    git/branch: e2e-branch
-    git/remote: git@github.com:SocialGouv/sample-kosko.git
-    app.gitlab.com/app: socialgouv-sample-kosko
-    app.gitlab.com/env: e2e-branch-42
-    app.gitlab.com/env.name: e2e-branch-dev2
-  labels:
-    azure-pg-admin-user: sample-kosko
-    application: e2e-branch-42-sample-kosko
-    owner: sample-kosko
-    team: sample-kosko
-    cert: wildcard
-  name: sample-kosko-24-e2e-branch-42
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/e2e/templates/autodevops/static-ingress-anotations/__tests__/__snapshots__/kosko generate --env prod.ts.snap
+++ b/e2e/templates/autodevops/static-ingress-anotations/__tests__/__snapshots__/kosko generate --env prod.ts.snap
@@ -2,27 +2,6 @@
 
 exports[`static-ingress-anotations: kosko generate --prod 1`] = `
 "---
-apiVersion: v1
-kind: Namespace
-metadata:
-  annotations:
-    socialgouv/creator: autodevops
-    janitor/ttl: 15d
-    field.cattle.io/creatorId: gitlab
-    field.cattle.io/projectId: c-bd7z2:p-7ms8p
-    git/branch: e2e-branch
-    git/remote: git@github.com:SocialGouv/sample-kosko.git
-    app.gitlab.com/app: socialgouv-sample-kosko
-    app.gitlab.com/env: e2e-branch-42
-    app.gitlab.com/env.name: e2e-branch-dev2
-  labels:
-    azure-pg-admin-user: sample-kosko
-    application: e2e-branch-42-sample-kosko
-    owner: sample-kosko
-    team: sample-kosko
-    cert: wildcard
-  name: sample-kosko-24-e2e-branch-42
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/e2e/templates/autodevops/static/__tests__/__snapshots__/kosko generate --env prod.ts.snap
+++ b/e2e/templates/autodevops/static/__tests__/__snapshots__/kosko generate --env prod.ts.snap
@@ -2,27 +2,6 @@
 
 exports[`static github: kosko generate --prod 1`] = `
 "---
-apiVersion: v1
-kind: Namespace
-metadata:
-  annotations:
-    socialgouv/creator: autodevops
-    field.cattle.io/creatorId: gitlab
-    field.cattle.io/projectId: c-bd7z2:p-7ms8p
-    git/branch: refs/heads/e2e-branch
-    git/remote: socialgouv/sample-kosko
-    app.github.com/job: xxxxxxx-job
-    app.github.com/ref: refs/heads/e2e-branch
-    app.github.com/repo: socialgouv/sample-kosko
-    app.github.com/run: '12345'
-    app.github.com/sha: '8843083'
-  labels:
-    azure-pg-admin-user: sample-kosko
-    application: sample-kosko
-    owner: sample-kosko
-    team: sample-kosko
-  name: sample-kosko
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -170,27 +149,6 @@ spec:
 
 exports[`static: kosko generate --prod 1`] = `
 "---
-apiVersion: v1
-kind: Namespace
-metadata:
-  annotations:
-    socialgouv/creator: autodevops
-    janitor/ttl: 15d
-    field.cattle.io/creatorId: gitlab
-    field.cattle.io/projectId: c-bd7z2:p-7ms8p
-    git/branch: e2e-branch
-    git/remote: git@github.com:SocialGouv/sample-kosko.git
-    app.gitlab.com/app: socialgouv-sample-kosko
-    app.gitlab.com/env: e2e-branch-42
-    app.gitlab.com/env.name: e2e-branch-dev2
-  labels:
-    azure-pg-admin-user: sample-kosko
-    application: e2e-branch-42-sample-kosko
-    owner: sample-kosko
-    team: sample-kosko
-    cert: wildcard
-  name: sample-kosko-24-e2e-branch-42
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/e2e/templates/autodevops/subdomain/__tests__/__snapshots__/kosko generate --env prod.ts.snap
+++ b/e2e/templates/autodevops/subdomain/__tests__/__snapshots__/kosko generate --env prod.ts.snap
@@ -2,27 +2,6 @@
 
 exports[`subdomain: kosko generate --prod 1`] = `
 "---
-apiVersion: v1
-kind: Namespace
-metadata:
-  annotations:
-    socialgouv/creator: autodevops
-    janitor/ttl: 15d
-    field.cattle.io/creatorId: gitlab
-    field.cattle.io/projectId: c-bd7z2:p-7ms8p
-    git/branch: e2e-branch
-    git/remote: git@github.com:SocialGouv/sample-kosko.git
-    app.gitlab.com/app: socialgouv-sample-kosko
-    app.gitlab.com/env: e2e-branch-42
-    app.gitlab.com/env.name: e2e-branch-dev2
-  labels:
-    azure-pg-admin-user: sample-kosko
-    application: e2e-branch-42-sample-kosko
-    owner: sample-kosko
-    team: sample-kosko
-    cert: wildcard
-  name: sample-kosko-24-e2e-branch-42
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/e2e/templates/autodevops/yaml/__tests__/__snapshots__/kosko generate --env prod.ts.snap
+++ b/e2e/templates/autodevops/yaml/__tests__/__snapshots__/kosko generate --env prod.ts.snap
@@ -2,27 +2,6 @@
 
 exports[`yaml: kosko generate --prod 1`] = `
 "---
-apiVersion: v1
-kind: Namespace
-metadata:
-  annotations:
-    socialgouv/creator: autodevops
-    janitor/ttl: 15d
-    field.cattle.io/creatorId: gitlab
-    field.cattle.io/projectId: c-bd7z2:p-7ms8p
-    git/branch: e2e-branch
-    git/remote: git@github.com:SocialGouv/sample-kosko.git
-    app.gitlab.com/app: socialgouv-sample-kosko
-    app.gitlab.com/env: e2e-branch-42
-    app.gitlab.com/env.name: e2e-branch-dev2
-  labels:
-    azure-pg-admin-user: sample-kosko
-    application: e2e-branch-42-sample-kosko
-    owner: sample-kosko
-    team: sample-kosko
-    cert: wildcard
-  name: sample-kosko-24-e2e-branch-42
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/templates/autodevops/kosko.toml
+++ b/templates/autodevops/kosko.toml
@@ -2,5 +2,5 @@
 components = ["!jobs", "*"]
 require = ["ts-node/register"]
 
-[environment.prod]
+[environments.prod]
 components = ["!jobs", "!_*", "*"]

--- a/templates/autodevops/kosko.toml
+++ b/templates/autodevops/kosko.toml
@@ -1,3 +1,6 @@
 # dont include jobs on deploys
 components = ["!jobs", "*"]
 require = ["ts-node/register"]
+
+[environment.prod]
+components = ["!jobs", "!_*", "*"]


### PR DESCRIPTION
as a convention, `_` prefixed components should be excluded from production