### PR TITLE
fix(app): fix very long hostnames

### DIFF
--- a/src/components/app/index.test.ts
+++ b/src/components/app/index.test.ts
@@ -1,7 +1,7 @@
 import { createNodeCJSEnvironment } from "@kosko/env";
 import environmentMock from "@socialgouv/kosko-charts/environments/index.mock";
 import { promises } from "fs";
-import { Ingress } from "kubernetes-models/_definitions/IoK8sApiNetworkingV1Ingress";
+import type { Ingress } from "kubernetes-models/_definitions/IoK8sApiNetworkingV1Ingress";
 import { directory } from "tempy";
 
 beforeEach(() => {
@@ -144,13 +144,13 @@ test("very long hostnames should be padded", async () => {
   const { create } = await import("./index");
   const manifests = await create("app", {
     config: {
-      subdomain: "some-very-very-very-very-very-very-long-subdomain",
       subDomainPrefix:
         "some-very-very-very-very-very-very-long-subdomain-prefix",
+      subdomain: "some-very-very-very-very-very-very-long-subdomain",
     },
     env,
   });
   const ingress = manifests.find((m) => m.kind === "Ingress") as Ingress;
-  //@ts-ignore-error
+  //@ts-expect-error-error
   expect(ingress.spec?.rules[0]?.host?.split(".")[0].length).toEqual(63);
 });

--- a/src/components/app/index.test.ts
+++ b/src/components/app/index.test.ts
@@ -1,6 +1,7 @@
 import { createNodeCJSEnvironment } from "@kosko/env";
 import environmentMock from "@socialgouv/kosko-charts/environments/index.mock";
 import { promises } from "fs";
+import { Ingress } from "kubernetes-models/_definitions/IoK8sApiNetworkingV1Ingress";
 import { directory } from "tempy";
 
 beforeEach(() => {
@@ -128,4 +129,28 @@ test("should return prod manifests without custom subdomain if undefined", async
       env,
     })
   ).toMatchSnapshot();
+});
+
+test("very long hostnames should be padded", async () => {
+  jest.doMock("@socialgouv/kosko-charts/environments", () => () => ({
+    ...environmentMock(),
+    isProduction: true,
+    tag: "v1.2.3",
+  }));
+  const cwd = directory();
+  const env = createNodeCJSEnvironment({ cwd });
+  env.env = "prod";
+  await promises.mkdir(`${cwd}/environments/prod`, { recursive: true });
+  const { create } = await import("./index");
+  const manifests = await create("app", {
+    config: {
+      subdomain: "some-very-very-very-very-very-very-long-subdomain",
+      subDomainPrefix:
+        "some-very-very-very-very-very-very-long-subdomain-prefix",
+    },
+    env,
+  });
+  const ingress = manifests.find((m) => m.kind === "Ingress") as Ingress;
+  //@ts-ignore-error
+  expect(ingress.spec?.rules[0]?.host?.split(".")[0].length).toEqual(63);
 });

--- a/src/components/app/index.ts
+++ b/src/components/app/index.ts
@@ -187,20 +187,24 @@ export const create: CreateFn = async (
   });
   manifests.push(service);
 
+  const MAX_HOSTNAME_SIZE = 63;
+  const shortenHost = (hostname: string) =>
+    hostname.slice(0, MAX_HOSTNAME_SIZE);
+
   /* INGRESS */
   if (envParams.ingress !== false) {
     let hosts = [
-      `${(envParams.subDomainPrefix || "") + ciEnv.metadata.subdomain}.${
-        ciEnv.metadata.domain
-      }`,
+      `${shortenHost(
+        (envParams.subDomainPrefix || "") + ciEnv.metadata.subdomain
+      )}.${ciEnv.metadata.domain}`,
     ];
 
     if (env.env === "prod") {
       hosts = [
-        `${
+        `${shortenHost(
           (envParams.subDomainPrefix || "") +
-          (envParams.subdomain || ciEnv.metadata.subdomain)
-        }.${envParams.domain || ciEnv.metadata.domain}`,
+            (envParams.subdomain || ciEnv.metadata.subdomain)
+        )}.${envParams.domain || ciEnv.metadata.domain}`,
       ];
     }
 
@@ -210,6 +214,7 @@ export const create: CreateFn = async (
       serviceName: name,
       isProduction: ciEnv.isProduction,
     });
+
     // add gitlab annotations
     updateMetadata(ingress, {
       annotations: envParams.annotations || {},


### PR DESCRIPTION
When we have a `subDomainPrefix`, its appended to the generated `subdomain`, resulting in a possibly strings longer than 63 chars which seems to break external-dns

https://www.freesoft.org/CIE/RFC/1035/9.htm