### PR TITLE
feat(namespace): reduce ttl

### DIFF
--- a/e2e/kitchen-sink/__tests__/__snapshots__/multihost.ts.snap
+++ b/e2e/kitchen-sink/__tests__/__snapshots__/multihost.ts.snap
@@ -7,7 +7,7 @@ kind: Namespace
 metadata:
   annotations:
     socialgouv/creator: autodevops
-    janitor/ttl: 15d
+    janitor/ttl: 7d
     field.cattle.io/creatorId: gitlab
     field.cattle.io/projectId: c-bd7z2:p-7ms8p
     git/branch: e2e-branch

--- a/e2e/templates/hasura/kosko generate/__tests__/__snapshots__/--env dev github.ts.snap
+++ b/e2e/templates/hasura/kosko generate/__tests__/__snapshots__/--env dev github.ts.snap
@@ -7,7 +7,7 @@ kind: Namespace
 metadata:
   annotations:
     socialgouv/creator: autodevops
-    janitor/ttl: 15d
+    janitor/ttl: 7d
     field.cattle.io/creatorId: gitlab
     field.cattle.io/projectId: c-bd7z2:p-7ms8p
     git/branch: refs/heads/e2e-branch

--- a/e2e/templates/hasura/kosko generate/__tests__/__snapshots__/--env dev.ts.snap
+++ b/e2e/templates/hasura/kosko generate/__tests__/__snapshots__/--env dev.ts.snap
@@ -7,7 +7,7 @@ kind: Namespace
 metadata:
   annotations:
     socialgouv/creator: autodevops
-    janitor/ttl: 15d
+    janitor/ttl: 7d
     field.cattle.io/creatorId: gitlab
     field.cattle.io/projectId: c-bd7z2:p-7ms8p
     git/branch: e2e-branch

--- a/e2e/templates/nginx/kosko generate/__tests__/__snapshots__/--env dev github.ts.snap
+++ b/e2e/templates/nginx/kosko generate/__tests__/__snapshots__/--env dev github.ts.snap
@@ -7,7 +7,7 @@ kind: Namespace
 metadata:
   annotations:
     socialgouv/creator: autodevops
-    janitor/ttl: 15d
+    janitor/ttl: 7d
     field.cattle.io/creatorId: gitlab
     field.cattle.io/projectId: c-bd7z2:p-7ms8p
     git/branch: refs/heads/e2e-branch

--- a/e2e/templates/nginx/kosko generate/__tests__/__snapshots__/--env dev.ts.snap
+++ b/e2e/templates/nginx/kosko generate/__tests__/__snapshots__/--env dev.ts.snap
@@ -7,7 +7,7 @@ kind: Namespace
 metadata:
   annotations:
     socialgouv/creator: autodevops
-    janitor/ttl: 15d
+    janitor/ttl: 7d
     field.cattle.io/creatorId: gitlab
     field.cattle.io/projectId: c-bd7z2:p-7ms8p
     git/branch: e2e-branch

--- a/e2e/templates/pgweb/kosko generate/__tests__/__snapshots__/--env dev github.ts.snap
+++ b/e2e/templates/pgweb/kosko generate/__tests__/__snapshots__/--env dev github.ts.snap
@@ -7,7 +7,7 @@ kind: Namespace
 metadata:
   annotations:
     socialgouv/creator: autodevops
-    janitor/ttl: 15d
+    janitor/ttl: 7d
     field.cattle.io/creatorId: gitlab
     field.cattle.io/projectId: c-bd7z2:p-7ms8p
     git/branch: refs/heads/e2e-branch

--- a/e2e/templates/pgweb/kosko generate/__tests__/__snapshots__/--env dev.ts.snap
+++ b/e2e/templates/pgweb/kosko generate/__tests__/__snapshots__/--env dev.ts.snap
@@ -7,7 +7,7 @@ kind: Namespace
 metadata:
   annotations:
     socialgouv/creator: autodevops
-    janitor/ttl: 15d
+    janitor/ttl: 7d
     field.cattle.io/creatorId: gitlab
     field.cattle.io/projectId: c-bd7z2:p-7ms8p
     git/branch: e2e-branch

--- a/e2e/templates/redis/kosko generate/__tests__/__snapshots__/--env dev github.ts.snap
+++ b/e2e/templates/redis/kosko generate/__tests__/__snapshots__/--env dev github.ts.snap
@@ -7,7 +7,7 @@ kind: Namespace
 metadata:
   annotations:
     socialgouv/creator: autodevops
-    janitor/ttl: 15d
+    janitor/ttl: 7d
     field.cattle.io/creatorId: gitlab
     field.cattle.io/projectId: c-bd7z2:p-7ms8p
     git/branch: refs/heads/e2e-branch

--- a/e2e/templates/redis/kosko generate/__tests__/__snapshots__/--env dev.ts.snap
+++ b/e2e/templates/redis/kosko generate/__tests__/__snapshots__/--env dev.ts.snap
@@ -7,7 +7,7 @@ kind: Namespace
 metadata:
   annotations:
     socialgouv/creator: autodevops
-    janitor/ttl: 15d
+    janitor/ttl: 7d
     field.cattle.io/creatorId: gitlab
     field.cattle.io/projectId: c-bd7z2:p-7ms8p
     git/branch: e2e-branch

--- a/e2e/templates/sample/kosko generate/__tests__/__snapshots__/--env dev github.ts.snap
+++ b/e2e/templates/sample/kosko generate/__tests__/__snapshots__/--env dev github.ts.snap
@@ -7,7 +7,7 @@ kind: Namespace
 metadata:
   annotations:
     socialgouv/creator: autodevops
-    janitor/ttl: 15d
+    janitor/ttl: 7d
     field.cattle.io/creatorId: gitlab
     field.cattle.io/projectId: c-bd7z2:p-7ms8p
     git/branch: refs/heads/e2e-branch

--- a/e2e/templates/sample/kosko generate/__tests__/__snapshots__/--env dev.ts.snap
+++ b/e2e/templates/sample/kosko generate/__tests__/__snapshots__/--env dev.ts.snap
@@ -7,7 +7,7 @@ kind: Namespace
 metadata:
   annotations:
     socialgouv/creator: autodevops
-    janitor/ttl: 15d
+    janitor/ttl: 7d
     field.cattle.io/creatorId: gitlab
     field.cattle.io/projectId: c-bd7z2:p-7ms8p
     git/branch: e2e-branch

--- a/e2e/testing/__fixtures__/__tests__/__snapshots__/kosko generate --env dev.ts.snap
+++ b/e2e/testing/__fixtures__/__tests__/__snapshots__/kosko generate --env dev.ts.snap
@@ -7,7 +7,7 @@ kind: Namespace
 metadata:
   annotations:
     socialgouv/creator: autodevops
-    janitor/ttl: 15d
+    janitor/ttl: 7d
     field.cattle.io/creatorId: gitlab
     field.cattle.io/projectId: c-bd7z2:p-7ms8p
     git/branch: master

--- a/src/components/namespace/__snapshots__/index.test.ts.snap
+++ b/src/components/namespace/__snapshots__/index.test.ts.snap
@@ -1,5 +1,31 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`renovate : should create a namespace with 1 day duration 1`] = `
+Object {
+  "apiVersion": "v1",
+  "kind": "Namespace",
+  "metadata": Object {
+    "annotations": Object {
+      "app.gitlab.com/app": "socialgouv-sample",
+      "app.gitlab.com/env": "my-test",
+      "field.cattle.io/creatorId": "gitlab",
+      "field.cattle.io/projectId": "",
+      "git/branch": "",
+      "git/remote": "",
+      "janitor/ttl": "1d",
+      "socialgouv/creator": "autodevops",
+    },
+    "labels": Object {
+      "application": "www",
+      "azure-pg-admin-user": "my-team",
+      "owner": "my-team",
+      "team": "my-team",
+    },
+    "name": "sample-42-my-test",
+  },
+}
+`;
+
 exports[`should create a namespace 1`] = `
 Object {
   "apiVersion": "v1",
@@ -12,7 +38,7 @@ Object {
       "field.cattle.io/projectId": "",
       "git/branch": "",
       "git/remote": "",
-      "janitor/ttl": "15d",
+      "janitor/ttl": "7d",
       "socialgouv/creator": "autodevops",
     },
     "labels": Object {
@@ -38,7 +64,7 @@ Object {
       "field.cattle.io/projectId": "",
       "git/branch": "",
       "git/remote": "",
-      "janitor/ttl": "15d",
+      "janitor/ttl": "7d",
       "socialgouv/creator": "autodevops",
     },
     "labels": Object {

--- a/src/components/namespace/index.test.ts
+++ b/src/components/namespace/index.test.ts
@@ -29,7 +29,22 @@ test("should create a namespace with extra labels and annotations", async () => 
     namespace.metadata &&
       namespace.metadata.annotations &&
       namespace.metadata.annotations["janitor/ttl"]
-  ).toEqual("15d");
+  ).toEqual("7d");
+});
+
+test("renovate : should create a namespace with 1 day duration", async () => {
+  jest.doMock("@socialgouv/kosko-charts/environments/gitlab", () => () => ({
+    ...environmentMock(),
+    branch: "renovate/pouet",
+  }));
+  const { createNamespace } = await import("./index");
+  const namespace = createNamespace();
+  expect(namespace).toMatchSnapshot();
+  expect(
+    namespace.metadata &&
+      namespace.metadata.annotations &&
+      namespace.metadata.annotations["janitor/ttl"]
+  ).toEqual("1d");
 });
 
 test("should NOT add janitor annotation if keepAlive set to true", async () => {

--- a/src/components/namespace/index.ts
+++ b/src/components/namespace/index.ts
@@ -18,7 +18,11 @@ export const createNamespace = (
   const isDestroyable = isDev && !envParams.keepAlive;
 
   if (isDestroyable) {
-    namespaceTtl["janitor/ttl"] = "15d";
+    let maxDuration = "7d";
+    if (ciEnv.branch.startsWith("renovate")) {
+      maxDuration = "1d";
+    }
+    namespaceTtl["janitor/ttl"] = maxDuration;
   }
 
   const namespace = new K8SNamespace({


### PR DESCRIPTION
 - reduce dev namespace ttl to 7 days instead of 15
 - defaults to 1 day for `renovate*` branches