### PR TITLE
fix(slug): Reduce slug size from 63 to 53 chars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [9.6.22-beta.1](https://github.com/SocialGouv/kosko-charts/compare/v9.6.21...v9.6.22-beta.1) (2021-11-03)
+
+
+### Bug Fixes
+
+* **slug:** Reduce slug size from 63 to 53 chars ([15d53cb](https://github.com/SocialGouv/kosko-charts/commit/15d53cb3433103b4c069d4a7be8771ac77e1aa91))
+
 ## [9.6.21](https://github.com/SocialGouv/kosko-charts/compare/v9.6.20...v9.6.21) (2021-10-29)
 
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Providing a common Kubernetes (k8s) configuration to SocialGouv apps is a tricky
 Powered by [Kosko](https://github.com/tommy351/kosko), in this lib we provide default SocialGouv components and environments. We expect project to use and extend them at will.
 
 ```sh
-$ npx degit "SocialGouv/kosko-charts/templates/sample#v9.6.21" .k8s
+$ npx degit "SocialGouv/kosko-charts/templates/sample#v9.6.22-beta.1" .k8s
 $ yarn --cwd .k8s
 # on GitLab
 $ yarn --cwd .k8s kosko generate --env dev
@@ -59,7 +59,7 @@ $ DOTENV_CONFIG_PATH=environments/.gitlab-ci.env yarn --cwd .k8s dev --require d
 We use [degit](https://github.com/Rich-Harris/degit) to scaffold the deployment config.
 
 ```sh
-$ npx degit "SocialGouv/kosko-charts/templates/sample#v9.6.21" .k8s
+$ npx degit "SocialGouv/kosko-charts/templates/sample#v9.6.22-beta.1" .k8s
 ```
 
 `.k8s` is the target deployment config package folder.
@@ -131,16 +131,16 @@ In addition to the `sample` template inspired by the [SocialGouv/sample-next-app
 
 ```sh
 # For [hasura](https://hasura.io/)
-$ npx degit "SocialGouv/kosko-charts/templates/hasura#v9.6.21" .k8s
+$ npx degit "SocialGouv/kosko-charts/templates/hasura#v9.6.22-beta.1" .k8s
 
 # For [nginx](https://nginx.org/)
-$ npx degit "SocialGouv/kosko-charts/templates/nginx#v9.6.21" .k8s
+$ npx degit "SocialGouv/kosko-charts/templates/nginx#v9.6.22-beta.1" .k8s
 
 # For [pgweb](https://sosedoff.github.io/pgweb/)
-$ npx degit "SocialGouv/kosko-charts/templates/pgweb#v9.6.21" .k8s
+$ npx degit "SocialGouv/kosko-charts/templates/pgweb#v9.6.22-beta.1" .k8s
 
 # For [redis](https://redislabs.com/)
-$ npx degit "SocialGouv/kosko-charts/templates/redis#v9.6.21" .k8s
+$ npx degit "SocialGouv/kosko-charts/templates/redis#v9.6.22-beta.1" .k8s
 ```
 
 ### Testing
@@ -149,7 +149,7 @@ $ npx degit "SocialGouv/kosko-charts/templates/redis#v9.6.21" .k8s
 
 ```
 # At the root of your project
-$ npx degit "SocialGouv/kosko-charts/templates/testing#v9.6.21" .k8s
+$ npx degit "SocialGouv/kosko-charts/templates/testing#v9.6.22-beta.1" .k8s
 ```
 
 Then update the `.k8s/__tests__` file to match your project.  

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@socialgouv/kosko-charts",
   "description": "Kosko charts for the SocialGouv needs",
-  "version": "9.6.21",
+  "version": "9.6.22-beta.1",
   "author": "Fabrique numérique des Ministères Sociaux <dsi-incubateur@sg.social.gouv.fr> (https://incubateur.social.gouv.fr)",
   "bugs": "https://github.com/SocialGouv/kosko-charts/issues",
   "dependencies": {

--- a/src/components/app/index.test.ts
+++ b/src/components/app/index.test.ts
@@ -152,5 +152,5 @@ test("very long hostnames should be padded", async () => {
   });
   const ingress = manifests.find((m) => m.kind === "Ingress") as Ingress;
   //@ts-expect-error-error
-  expect(ingress.spec?.rules[0]?.host?.split(".")[0].length).toEqual(63);
+  expect(ingress.spec?.rules[0]?.host?.split(".")[0].length).toEqual(53);
 });

--- a/src/components/app/index.ts
+++ b/src/components/app/index.ts
@@ -187,7 +187,7 @@ export const create: CreateFn = async (
   });
   manifests.push(service);
 
-  const MAX_HOSTNAME_SIZE = 63;
+  const MAX_HOSTNAME_SIZE = 53;
   const shortenHost = (hostname: string) =>
     hostname.slice(0, MAX_HOSTNAME_SIZE);
 

--- a/src/environments/github/index.test.ts
+++ b/src/environments/github/index.test.ts
@@ -83,10 +83,10 @@ test("the generated namespace name should not be longer that 63 chars", () => {
       "refs/heads/douglasduteil/build-k8s-make-the-preprod-a-anonym-data-mirror-of-the-production",
   };
 
-  expect(env(testEnv).metadata.namespace.name.length).toBeLessThan(63);
+  expect(env(testEnv).metadata.namespace.name.length).toBeLessThan(53);
   expect(env(testEnv).metadata.namespace).toMatchInlineSnapshot(`
-Object {
-  "name": "sample-next-app-douglasduteil-build-k8s-make-the-prepro-2kt5sc",
-}
-`);
+    Object {
+      "name": "sample-next-app-douglasduteil-build-k8s-make-2kt5sc",
+    }
+  `);
 });

--- a/src/utils/environmentSlug.test.ts
+++ b/src/utils/environmentSlug.test.ts
@@ -43,8 +43,8 @@ ${"v0.1.1"} | ${"v0-1-1-21ni6m"}
 ${"v1.1.1"} | ${"v1-1-1-3k7de0"}
 ...
 ${"renovate/socialgouvdocker-images"} | ${"renovate-socialgouvdocker-images-1e66b4"}
-${"douglasduteil/very-very-very-very-very-long-branch-name!"} | ${"douglasduteil-very-very-very-very-very-long-branch-name-5z9ugw"}
-${"douglasduteil/very-very-very-very-very-very-long-branch-name!"} | ${"douglasduteil-very-very-very-very-very-very-long-branch-1u0g3l"}
+${"douglasduteil/very-very-very-very-very-long-branch-name!"} | ${"douglasduteil-very-very-very-very-very-long-b-5z9ugw"}
+${"douglasduteil/very-very-very-very-very-very-long-branch-name!"} | ${"douglasduteil-very-very-very-very-very-very-l-1u0g3l"}
 `(
   "'$name' 's slug should be '$expected'",
   ({ name, expected }: { name: string; expected: string }) => {

--- a/src/utils/environmentSlug.ts
+++ b/src/utils/environmentSlug.ts
@@ -11,7 +11,7 @@ slugify.extend({ "!": "-", ".": "-", "/": "-", "@": "-", _: "-", "~": "-" });
 
 //
 
-const KUBERNETS_MAX_NAME_LENGTH = 63;
+const KUBERNETS_MAX_NAME_LENGTH = 53;
 const SUFFIX_SHA_LENGTH = 8;
 
 //

--- a/templates/autodevops/package.json
+++ b/templates/autodevops/package.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "@kosko/env": "^2.0.1",
     "@kubernetes-models/sealed-secrets": "^2.0.2",
-    "@socialgouv/kosko-charts": "9.6.21",
+    "@socialgouv/kosko-charts": "9.6.22-beta.1",
     "@types/node": "^16.11.6",
     "kosko": "^1.1.5",
     "kubernetes-models": "^2.0.2",

--- a/templates/hasura/package.json
+++ b/templates/hasura/package.json
@@ -4,7 +4,7 @@
     "kubernetes-models": "^2.0.2"
   },
   "devDependencies": {
-    "@socialgouv/kosko-charts": "9.6.21",
+    "@socialgouv/kosko-charts": "9.6.22-beta.1",
     "@types/node": "^16.11.6",
     "dotenv": "^10.0.0",
     "kosko": "^1.1.5",

--- a/templates/nginx/package.json
+++ b/templates/nginx/package.json
@@ -4,7 +4,7 @@
     "kubernetes-models": "^2.0.2"
   },
   "devDependencies": {
-    "@socialgouv/kosko-charts": "9.6.21",
+    "@socialgouv/kosko-charts": "9.6.22-beta.1",
     "@types/node": "^16.11.6",
     "dotenv": "^10.0.0",
     "kosko": "^1.1.5",

--- a/templates/pgweb/package.json
+++ b/templates/pgweb/package.json
@@ -4,7 +4,7 @@
     "kubernetes-models": "^2.0.2"
   },
   "devDependencies": {
-    "@socialgouv/kosko-charts": "9.6.21",
+    "@socialgouv/kosko-charts": "9.6.22-beta.1",
     "@types/node": "^16.11.6",
     "dotenv": "^10.0.0",
     "kosko": "^1.1.5",

--- a/templates/redis/package.json
+++ b/templates/redis/package.json
@@ -4,7 +4,7 @@
     "kubernetes-models": "^2.0.2"
   },
   "devDependencies": {
-    "@socialgouv/kosko-charts": "9.6.21",
+    "@socialgouv/kosko-charts": "9.6.22-beta.1",
     "@types/node": "^16.11.6",
     "dotenv": "^10.0.0",
     "kosko": "^1.1.5",

--- a/templates/sample/package.json
+++ b/templates/sample/package.json
@@ -4,7 +4,7 @@
     "kubernetes-models": "^2.0.2"
   },
   "devDependencies": {
-    "@socialgouv/kosko-charts": "9.6.21",
+    "@socialgouv/kosko-charts": "9.6.22-beta.1",
     "@types/node": "^16.11.6",
     "dotenv": "^10.0.0",
     "kosko": "^1.1.5",

--- a/templates/testing/package.json
+++ b/templates/testing/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@kosko/env": "^2.0.1",
     "@kubernetes-models/sealed-secrets": "^2.0.2",
-    "@socialgouv/kosko-charts": "9.6.21",
+    "@socialgouv/kosko-charts": "9.6.22-beta.1",
     "@types/node": "^16.11.6",
     "kosko": "^1.1.5",
     "kubernetes-models": "^2.0.2",


### PR DESCRIPTION
Trying to avoid too long `subdomain` problem.

Example:
- Working DNS/URL: https://api-code-du-travail-numerique-maxgfr-checkbox-53v22r.dev.fabrique.social.gouv.fr/
- Non working DNS/URL: https://api-code-du-travail-numerique-carolinebda-fix-remains-html-3yw7vf.dev.fabrique.social.gouv.fr/

Note that the Gitlab CI documentation says (https://docs.gitlab.com/14.4/ee/ci/variables/predefined_variables.html):
`CI_ENVIRONMENT_SLUG `: `The simplified version of the environment name, suitable for inclusion in DNS, URLs, Kubernetes labels, and so on. Available if environment:name is set. The slug is truncated to 24 characters.`

But a ticket linked to the doc talks about 63 chars: https://gitlab.com/gitlab-org/gitlab/-/issues/20941