### PR TITLE
fix(netpol): use podSelector + fix default name

### DIFF
--- a/src/components/netpol/__snapshots__/index.test.ts.snap
+++ b/src/components/netpol/__snapshots__/index.test.ts.snap
@@ -5,7 +5,7 @@ Object {
   "apiVersion": "networking.k8s.io/v1",
   "kind": "NetworkPolicy",
   "metadata": Object {
-    "name": "default",
+    "name": "netpol-some-app",
     "namespace": "some-app",
   },
   "spec": Object {
@@ -13,11 +13,7 @@ Object {
       Object {
         "from": Array [
           Object {
-            "namespaceSelector": Object {
-              "matchLabels": Object {
-                "network-policy/namespace": "some-app",
-              },
-            },
+            "podSelector": Object {},
           },
         ],
       },

--- a/src/components/netpol/index.ts
+++ b/src/components/netpol/index.ts
@@ -8,15 +8,13 @@ import { NetworkPolicy } from "kubernetes-models/networking.k8s.io/v1/NetworkPol
 
 export const create = (namespace: string): NetworkPolicy =>
   new NetworkPolicy({
-    metadata: { name: "default", namespace },
+    metadata: { name: `netpol-${namespace}`, namespace },
     spec: {
       ingress: [
         {
           from: [
             {
-              namespaceSelector: {
-                matchLabels: { "network-policy/namespace": namespace },
-              },
+              podSelector: {},
             },
           ],
         },


### PR DESCRIPTION
 - change le nom de la netpol par défaut en `netpol-[namespace]`
 - utilise `podSelector` au lieu de `namespaceSelector` + labels