### PR TITLE
fix(netpol): use default namespace

### DIFF
--- a/src/components/netpol/__snapshots__/index.test.ts.snap
+++ b/src/components/netpol/__snapshots__/index.test.ts.snap
@@ -5,6 +5,54 @@ Object {
   "apiVersion": "networking.k8s.io/v1",
   "kind": "NetworkPolicy",
   "metadata": Object {
+    "name": "netpol-sample-42-my-test",
+    "namespace": "sample-42-my-test",
+  },
+  "spec": Object {
+    "ingress": Array [
+      Object {
+        "from": Array [
+          Object {
+            "podSelector": Object {},
+          },
+        ],
+      },
+      Object {
+        "from": Array [
+          Object {
+            "namespaceSelector": Object {
+              "matchLabels": Object {
+                "network-policy/source": "ingress-controller",
+              },
+            },
+          },
+        ],
+      },
+      Object {
+        "from": Array [
+          Object {
+            "namespaceSelector": Object {
+              "matchLabels": Object {
+                "network-policy/source": "monitoring",
+              },
+            },
+          },
+        ],
+      },
+    ],
+    "podSelector": Object {},
+    "policyTypes": Array [
+      "Ingress",
+    ],
+  },
+}
+`;
+
+exports[`should create a network policy with custom namespace 1`] = `
+Object {
+  "apiVersion": "networking.k8s.io/v1",
+  "kind": "NetworkPolicy",
+  "metadata": Object {
     "name": "netpol-some-app",
     "namespace": "some-app",
   },

--- a/src/components/netpol/index.test.ts
+++ b/src/components/netpol/index.test.ts
@@ -1,11 +1,19 @@
-//
+import environmentMock from "@socialgouv/kosko-charts/environments/index.mock";
 
 beforeEach(() => {
   jest.resetModules();
 });
 
-test("should create a network policy", async () => {
+test("should create a network policy with custom namespace", async () => {
+  jest.doMock("@socialgouv/kosko-charts/environments", () => environmentMock);
   const { create } = await import("./index");
   const netpol = create("some-app");
+  expect(netpol).toMatchSnapshot();
+});
+
+test("should create a network policy", async () => {
+  jest.doMock("@socialgouv/kosko-charts/environments", () => environmentMock);
+  const { create } = await import("./index");
+  const netpol = create();
   expect(netpol).toMatchSnapshot();
 });

--- a/src/components/netpol/index.ts
+++ b/src/components/netpol/index.ts
@@ -1,3 +1,4 @@
+import environments from "@socialgouv/kosko-charts/environments";
 import { NetworkPolicy } from "kubernetes-models/networking.k8s.io/v1/NetworkPolicy";
 
 /**  Basic netpol that allow :
@@ -6,9 +7,11 @@ import { NetworkPolicy } from "kubernetes-models/networking.k8s.io/v1/NetworkPol
 /*      - communication from monitoring
 */
 
-export const create = (namespace: string): NetworkPolicy =>
-  new NetworkPolicy({
-    metadata: { name: `netpol-${namespace}`, namespace },
+export const create = (namespace?: string): NetworkPolicy => {
+  const ciEnv = environments(process.env);
+  const ns = namespace || ciEnv.metadata.namespace.name;
+  return new NetworkPolicy({
+    metadata: { name: `netpol-${ns}`, namespace: ns },
     spec: {
       ingress: [
         {
@@ -45,3 +48,4 @@ export const create = (namespace: string): NetworkPolicy =>
       policyTypes: ["Ingress"],
     },
   });
+};

--- a/src/components/netpol/index.ts
+++ b/src/components/netpol/index.ts
@@ -9,7 +9,7 @@ import { NetworkPolicy } from "kubernetes-models/networking.k8s.io/v1/NetworkPol
 
 export const create = (namespace?: string): NetworkPolicy => {
   const ciEnv = environments(process.env);
-  const ns = namespace || ciEnv.metadata.namespace.name;
+  const ns = namespace ?? ciEnv.metadata.namespace.name;
   return new NetworkPolicy({
     metadata: { name: `netpol-${ns}`, namespace: ns },
     spec: {

--- a/src/components/pg/create-db-user.job.test.ts
+++ b/src/components/pg/create-db-user.job.test.ts
@@ -7,7 +7,6 @@ test("should create a pg create-db-user job", () => {
     ciEnv: environmentMock(),
     pgPasswordSecretKeyRef: "azure-pg-user-preprod",
   });
-  console.log(job);
   expect(job).toMatchInlineSnapshot(`
     Object {
       "apiVersion": "batch/v1",


### PR DESCRIPTION
Use namespace from environment if not provided

Allow usage of: 

```js
import { create } from "@socialgouv/kosko-charts/components/netpol";

export default create();
```