### PR TITLE
feat(autodevops): enable netpols

### DIFF
--- a/e2e/templates/autodevops/app-ingress-anotations/__tests__/__snapshots__/kosko generate --env dev.ts.snap
+++ b/e2e/templates/autodevops/app-ingress-anotations/__tests__/__snapshots__/kosko generate --env dev.ts.snap
@@ -144,5 +144,26 @@ spec:
   tls:
     - hosts:
         - e2e-branch-42-sample-kosko.dev2.fabrique.social.gouv.fr
-      secretName: wildcard-crt"
+      secretName: wildcard-crt
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: netpol-sample-kosko-24-e2e-branch-42
+  namespace: sample-kosko-24-e2e-branch-42
+spec:
+  ingress:
+    - from:
+        - podSelector: {}
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: ingress-controller
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: monitoring
+  podSelector: {}
+  policyTypes:
+    - Ingress"
 `;

--- a/e2e/templates/autodevops/app-ingress-anotations/__tests__/__snapshots__/kosko generate --env preprod.ts.snap
+++ b/e2e/templates/autodevops/app-ingress-anotations/__tests__/__snapshots__/kosko generate --env preprod.ts.snap
@@ -144,5 +144,26 @@ spec:
   tls:
     - hosts:
         - e2e-branch-42-sample-kosko.dev2.fabrique.social.gouv.fr
-      secretName: wildcard-crt"
+      secretName: wildcard-crt
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: netpol-sample-kosko-24-e2e-branch-42
+  namespace: sample-kosko-24-e2e-branch-42
+spec:
+  ingress:
+    - from:
+        - podSelector: {}
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: ingress-controller
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: monitoring
+  podSelector: {}
+  policyTypes:
+    - Ingress"
 `;

--- a/e2e/templates/autodevops/app-ingress-anotations/__tests__/__snapshots__/kosko generate --env prod.ts.snap
+++ b/e2e/templates/autodevops/app-ingress-anotations/__tests__/__snapshots__/kosko generate --env prod.ts.snap
@@ -144,5 +144,26 @@ spec:
   tls:
     - hosts:
         - e2e-branch-42-sample-kosko.dev2.fabrique.social.gouv.fr
-      secretName: wildcard-crt"
+      secretName: wildcard-crt
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: netpol-sample-kosko-24-e2e-branch-42
+  namespace: sample-kosko-24-e2e-branch-42
+spec:
+  ingress:
+    - from:
+        - podSelector: {}
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: ingress-controller
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: monitoring
+  podSelector: {}
+  policyTypes:
+    - Ingress"
 `;

--- a/e2e/templates/autodevops/app-no-netpol/__tests__/__snapshots__/kosko generate --env dev.ts.snap
+++ b/e2e/templates/autodevops/app-no-netpol/__tests__/__snapshots__/kosko generate --env dev.ts.snap
@@ -1,28 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`static-ingress-anotations: kosko generate --preprod 1`] = `
+exports[`app-ingress-annotations: kosko generate --dev 1`] = `
 "---
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  name: netpol-sample-kosko-24-e2e-branch-42
-  namespace: sample-kosko-24-e2e-branch-42
-spec:
-  ingress:
-    - from:
-        - podSelector: {}
-    - from:
-        - namespaceSelector:
-            matchLabels:
-              network-policy/source: ingress-controller
-    - from:
-        - namespaceSelector:
-            matchLabels:
-              network-policy/source: monitoring
-  podSelector: {}
-  policyTypes:
-    - Ingress
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -33,19 +12,19 @@ metadata:
     app.gitlab.com/env: e2e-branch-42
     app.gitlab.com/env.name: e2e-branch-dev2
   labels:
-    app: static-ingress-annotations
+    app: app-no-netpol
     application: e2e-branch-42-sample-kosko
-    component: nginx
+    component: e2e-branch-42-sample-kosko
     owner: sample-kosko
     team: sample-kosko
     cert: wildcard
-  name: static-ingress-annotations
+  name: app-no-netpol
   namespace: sample-kosko-24-e2e-branch-42
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: static-ingress-annotations
+      app: app-no-netpol
   template:
     metadata:
       annotations:
@@ -55,32 +34,32 @@ spec:
         app.gitlab.com/env: e2e-branch-42
         app.gitlab.com/env.name: e2e-branch-dev2
       labels:
-        app: static-ingress-annotations
+        app: app-no-netpol
         application: e2e-branch-42-sample-kosko
-        component: nginx
+        component: e2e-branch-42-sample-kosko
         owner: sample-kosko
         team: sample-kosko
         cert: wildcard
     spec:
       containers:
         - image: >-
-            harbor.fabrique.social.gouv.fr/undefined/static-ingress-annotations:8843083edb7f873cad1d1420731a60773594ffae
+            harbor.fabrique.social.gouv.fr/undefined/app-no-netpol:8843083edb7f873cad1d1420731a60773594ffae
           livenessProbe:
             failureThreshold: 6
             httpGet:
-              path: /index.html
+              path: /healthz
               port: http
             initialDelaySeconds: 30
             periodSeconds: 5
             timeoutSeconds: 5
-          name: static-ingress-annotations
+          name: app-no-netpol
           ports:
-            - containerPort: 80
+            - containerPort: 3000
               name: http
           readinessProbe:
             failureThreshold: 15
             httpGet:
-              path: /index.html
+              path: /healthz
               port: http
             initialDelaySeconds: 0
             periodSeconds: 5
@@ -88,29 +67,32 @@ spec:
             timeoutSeconds: 1
           resources:
             limits:
-              cpu: 500m
-              memory: 128Mi
+              cpu: 200m
+              memory: 256Mi
             requests:
-              cpu: 5m
-              memory: 32Mi
+              cpu: 50m
+              memory: 128Mi
           startupProbe:
             failureThreshold: 12
             httpGet:
-              path: /index.html
+              path: /healthz
               port: http
             periodSeconds: 5
+          env:
+            - name: APP_BASE_URL
+              value: https://e2e-branch-42-sample-kosko.dev2.fabrique.social.gouv.fr
 ---
 apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: static-ingress-annotations
+    app: app-no-netpol
     application: e2e-branch-42-sample-kosko
-    component: nginx
+    component: e2e-branch-42-sample-kosko
     owner: sample-kosko
     team: sample-kosko
     cert: wildcard
-  name: static-ingress-annotations
+  name: app-no-netpol
   annotations:
     kapp.k14s.io/disable-default-ownership-label-rules: ''
     kapp.k14s.io/disable-default-label-scoping-rules: ''
@@ -122,9 +104,9 @@ spec:
   ports:
     - name: http
       port: 80
-      targetPort: 80
+      targetPort: 3000
   selector:
-    app: static-ingress-annotations
+    app: app-no-netpol
   type: ClusterIP
 ---
 apiVersion: networking.k8s.io/v1
@@ -137,15 +119,14 @@ metadata:
     app.gitlab.com/app: socialgouv-sample-kosko
     app.gitlab.com/env: e2e-branch-42
     app.gitlab.com/env.name: e2e-branch-dev2
-    nginx.ingress.kubernetes.io/configuration-snippet: 'more_set_headers \\"X-Answer: 42\\";'
   labels:
-    app: static-ingress-annotations
+    app: app-no-netpol
     application: e2e-branch-42-sample-kosko
-    component: nginx
+    component: e2e-branch-42-sample-kosko
     owner: sample-kosko
     team: sample-kosko
     cert: wildcard
-  name: static-ingress-annotations
+  name: app-no-netpol
   namespace: sample-kosko-24-e2e-branch-42
 spec:
   rules:
@@ -154,7 +135,7 @@ spec:
         paths:
           - backend:
               service:
-                name: static-ingress-annotations
+                name: app-no-netpol
                 port:
                   name: http
             path: /

--- a/e2e/templates/autodevops/app-no-netpol/__tests__/__snapshots__/kosko generate --env preprod.ts.snap
+++ b/e2e/templates/autodevops/app-no-netpol/__tests__/__snapshots__/kosko generate --env preprod.ts.snap
@@ -1,28 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`static-ingress-anotations: kosko generate --preprod 1`] = `
+exports[`app-ingress-annotations: kosko generate --preprod 1`] = `
 "---
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  name: netpol-sample-kosko-24-e2e-branch-42
-  namespace: sample-kosko-24-e2e-branch-42
-spec:
-  ingress:
-    - from:
-        - podSelector: {}
-    - from:
-        - namespaceSelector:
-            matchLabels:
-              network-policy/source: ingress-controller
-    - from:
-        - namespaceSelector:
-            matchLabels:
-              network-policy/source: monitoring
-  podSelector: {}
-  policyTypes:
-    - Ingress
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -33,19 +12,19 @@ metadata:
     app.gitlab.com/env: e2e-branch-42
     app.gitlab.com/env.name: e2e-branch-dev2
   labels:
-    app: static-ingress-annotations
+    app: app-no-netpol
     application: e2e-branch-42-sample-kosko
-    component: nginx
+    component: e2e-branch-42-sample-kosko
     owner: sample-kosko
     team: sample-kosko
     cert: wildcard
-  name: static-ingress-annotations
+  name: app-no-netpol
   namespace: sample-kosko-24-e2e-branch-42
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: static-ingress-annotations
+      app: app-no-netpol
   template:
     metadata:
       annotations:
@@ -55,32 +34,32 @@ spec:
         app.gitlab.com/env: e2e-branch-42
         app.gitlab.com/env.name: e2e-branch-dev2
       labels:
-        app: static-ingress-annotations
+        app: app-no-netpol
         application: e2e-branch-42-sample-kosko
-        component: nginx
+        component: e2e-branch-42-sample-kosko
         owner: sample-kosko
         team: sample-kosko
         cert: wildcard
     spec:
       containers:
         - image: >-
-            harbor.fabrique.social.gouv.fr/undefined/static-ingress-annotations:8843083edb7f873cad1d1420731a60773594ffae
+            harbor.fabrique.social.gouv.fr/undefined/app-no-netpol:8843083edb7f873cad1d1420731a60773594ffae
           livenessProbe:
             failureThreshold: 6
             httpGet:
-              path: /index.html
+              path: /healthz
               port: http
             initialDelaySeconds: 30
             periodSeconds: 5
             timeoutSeconds: 5
-          name: static-ingress-annotations
+          name: app-no-netpol
           ports:
-            - containerPort: 80
+            - containerPort: 3000
               name: http
           readinessProbe:
             failureThreshold: 15
             httpGet:
-              path: /index.html
+              path: /healthz
               port: http
             initialDelaySeconds: 0
             periodSeconds: 5
@@ -88,29 +67,32 @@ spec:
             timeoutSeconds: 1
           resources:
             limits:
-              cpu: 500m
-              memory: 128Mi
+              cpu: 200m
+              memory: 256Mi
             requests:
-              cpu: 5m
-              memory: 32Mi
+              cpu: 50m
+              memory: 128Mi
           startupProbe:
             failureThreshold: 12
             httpGet:
-              path: /index.html
+              path: /healthz
               port: http
             periodSeconds: 5
+          env:
+            - name: APP_BASE_URL
+              value: https://e2e-branch-42-sample-kosko.dev2.fabrique.social.gouv.fr
 ---
 apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: static-ingress-annotations
+    app: app-no-netpol
     application: e2e-branch-42-sample-kosko
-    component: nginx
+    component: e2e-branch-42-sample-kosko
     owner: sample-kosko
     team: sample-kosko
     cert: wildcard
-  name: static-ingress-annotations
+  name: app-no-netpol
   annotations:
     kapp.k14s.io/disable-default-ownership-label-rules: ''
     kapp.k14s.io/disable-default-label-scoping-rules: ''
@@ -122,9 +104,9 @@ spec:
   ports:
     - name: http
       port: 80
-      targetPort: 80
+      targetPort: 3000
   selector:
-    app: static-ingress-annotations
+    app: app-no-netpol
   type: ClusterIP
 ---
 apiVersion: networking.k8s.io/v1
@@ -137,15 +119,14 @@ metadata:
     app.gitlab.com/app: socialgouv-sample-kosko
     app.gitlab.com/env: e2e-branch-42
     app.gitlab.com/env.name: e2e-branch-dev2
-    nginx.ingress.kubernetes.io/configuration-snippet: 'more_set_headers \\"X-Answer: 42\\";'
   labels:
-    app: static-ingress-annotations
+    app: app-no-netpol
     application: e2e-branch-42-sample-kosko
-    component: nginx
+    component: e2e-branch-42-sample-kosko
     owner: sample-kosko
     team: sample-kosko
     cert: wildcard
-  name: static-ingress-annotations
+  name: app-no-netpol
   namespace: sample-kosko-24-e2e-branch-42
 spec:
   rules:
@@ -154,7 +135,7 @@ spec:
         paths:
           - backend:
               service:
-                name: static-ingress-annotations
+                name: app-no-netpol
                 port:
                   name: http
             path: /

--- a/e2e/templates/autodevops/app-no-netpol/__tests__/__snapshots__/kosko generate --env prod.ts.snap
+++ b/e2e/templates/autodevops/app-no-netpol/__tests__/__snapshots__/kosko generate --env prod.ts.snap
@@ -1,28 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`static-ingress-anotations: kosko generate --preprod 1`] = `
+exports[`app-ingress-annotations: kosko generate --prod 1`] = `
 "---
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  name: netpol-sample-kosko-24-e2e-branch-42
-  namespace: sample-kosko-24-e2e-branch-42
-spec:
-  ingress:
-    - from:
-        - podSelector: {}
-    - from:
-        - namespaceSelector:
-            matchLabels:
-              network-policy/source: ingress-controller
-    - from:
-        - namespaceSelector:
-            matchLabels:
-              network-policy/source: monitoring
-  podSelector: {}
-  policyTypes:
-    - Ingress
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -33,19 +12,19 @@ metadata:
     app.gitlab.com/env: e2e-branch-42
     app.gitlab.com/env.name: e2e-branch-dev2
   labels:
-    app: static-ingress-annotations
+    app: app-no-netpol
     application: e2e-branch-42-sample-kosko
-    component: nginx
+    component: e2e-branch-42-sample-kosko
     owner: sample-kosko
     team: sample-kosko
     cert: wildcard
-  name: static-ingress-annotations
+  name: app-no-netpol
   namespace: sample-kosko-24-e2e-branch-42
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: static-ingress-annotations
+      app: app-no-netpol
   template:
     metadata:
       annotations:
@@ -55,32 +34,32 @@ spec:
         app.gitlab.com/env: e2e-branch-42
         app.gitlab.com/env.name: e2e-branch-dev2
       labels:
-        app: static-ingress-annotations
+        app: app-no-netpol
         application: e2e-branch-42-sample-kosko
-        component: nginx
+        component: e2e-branch-42-sample-kosko
         owner: sample-kosko
         team: sample-kosko
         cert: wildcard
     spec:
       containers:
         - image: >-
-            harbor.fabrique.social.gouv.fr/undefined/static-ingress-annotations:8843083edb7f873cad1d1420731a60773594ffae
+            harbor.fabrique.social.gouv.fr/undefined/app-no-netpol:8843083edb7f873cad1d1420731a60773594ffae
           livenessProbe:
             failureThreshold: 6
             httpGet:
-              path: /index.html
+              path: /healthz
               port: http
             initialDelaySeconds: 30
             periodSeconds: 5
             timeoutSeconds: 5
-          name: static-ingress-annotations
+          name: app-no-netpol
           ports:
-            - containerPort: 80
+            - containerPort: 3000
               name: http
           readinessProbe:
             failureThreshold: 15
             httpGet:
-              path: /index.html
+              path: /healthz
               port: http
             initialDelaySeconds: 0
             periodSeconds: 5
@@ -88,29 +67,32 @@ spec:
             timeoutSeconds: 1
           resources:
             limits:
-              cpu: 500m
-              memory: 128Mi
+              cpu: 200m
+              memory: 256Mi
             requests:
-              cpu: 5m
-              memory: 32Mi
+              cpu: 50m
+              memory: 128Mi
           startupProbe:
             failureThreshold: 12
             httpGet:
-              path: /index.html
+              path: /healthz
               port: http
             periodSeconds: 5
+          env:
+            - name: APP_BASE_URL
+              value: https://e2e-branch-42-sample-kosko.dev2.fabrique.social.gouv.fr
 ---
 apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: static-ingress-annotations
+    app: app-no-netpol
     application: e2e-branch-42-sample-kosko
-    component: nginx
+    component: e2e-branch-42-sample-kosko
     owner: sample-kosko
     team: sample-kosko
     cert: wildcard
-  name: static-ingress-annotations
+  name: app-no-netpol
   annotations:
     kapp.k14s.io/disable-default-ownership-label-rules: ''
     kapp.k14s.io/disable-default-label-scoping-rules: ''
@@ -122,9 +104,9 @@ spec:
   ports:
     - name: http
       port: 80
-      targetPort: 80
+      targetPort: 3000
   selector:
-    app: static-ingress-annotations
+    app: app-no-netpol
   type: ClusterIP
 ---
 apiVersion: networking.k8s.io/v1
@@ -137,15 +119,14 @@ metadata:
     app.gitlab.com/app: socialgouv-sample-kosko
     app.gitlab.com/env: e2e-branch-42
     app.gitlab.com/env.name: e2e-branch-dev2
-    nginx.ingress.kubernetes.io/configuration-snippet: 'more_set_headers \\"X-Answer: 42\\";'
   labels:
-    app: static-ingress-annotations
+    app: app-no-netpol
     application: e2e-branch-42-sample-kosko
-    component: nginx
+    component: e2e-branch-42-sample-kosko
     owner: sample-kosko
     team: sample-kosko
     cert: wildcard
-  name: static-ingress-annotations
+  name: app-no-netpol
   namespace: sample-kosko-24-e2e-branch-42
 spec:
   rules:
@@ -154,7 +135,7 @@ spec:
         paths:
           - backend:
               service:
-                name: static-ingress-annotations
+                name: app-no-netpol
                 port:
                   name: http
             path: /

--- a/e2e/templates/autodevops/app-no-netpol/__tests__/config.json
+++ b/e2e/templates/autodevops/app-no-netpol/__tests__/config.json
@@ -1,0 +1,5 @@
+{
+  "name": "app-no-netpol",
+  "type": "app",
+  "netpol": false
+}

--- a/e2e/templates/autodevops/app-no-netpol/__tests__/kosko generate --env dev.ts
+++ b/e2e/templates/autodevops/app-no-netpol/__tests__/kosko generate --env dev.ts
@@ -1,0 +1,50 @@
+//
+
+import { config } from "dotenv";
+import { KOSKO_BIN, template, TIMEOUT } from "e2e/templates/helpers";
+import execa from "execa";
+import { basename, resolve } from "path";
+
+//
+
+const cwd = template(basename(resolve(__dirname, "..", "..")));
+
+test(
+  "app-ingress-annotations: kosko generate --dev",
+  async () => {
+    const gitlabEnv = config({
+      path: resolve(cwd, "./environments/.gitlab-ci.env"),
+    }).parsed;
+
+    const env = {
+      ...gitlabEnv,
+      SOCIALGOUV_CONFIG_PATH: __dirname + "/config.json",
+    };
+
+    // Required to allow seemless integration code example
+    const result = await execa.node(KOSKO_BIN, ["generate", "--env", "dev"], {
+      cwd,
+      env,
+    });
+
+    expect(result.stdout).toMatchSnapshot();
+    expect(result.exitCode).toEqual(0);
+  },
+  TIMEOUT
+);
+
+// //
+
+// import { getEnvManifests } from "@socialgouv/kosko-charts/testing"
+// import { project } from "@socialgouv/kosko-charts/testing/fake/gitlab-ci.env"
+
+// jest.setTimeout(1000 * 60)
+
+// test("app: kosko generate --dev", async () => {
+//   expect(
+//     await getEnvManifests("dev", "", {
+//       ...project("myapp").dev,
+//       SOCIALGOUV_CONFIG_PATH: __dirname + "/config.json",
+//     })
+//   ).toMatchSnapshot()
+// })

--- a/e2e/templates/autodevops/app-no-netpol/__tests__/kosko generate --env preprod.ts
+++ b/e2e/templates/autodevops/app-no-netpol/__tests__/kosko generate --env preprod.ts
@@ -1,0 +1,35 @@
+//
+
+import { config } from "dotenv";
+import { KOSKO_BIN, template, TIMEOUT } from "e2e/templates/helpers";
+import execa from "execa";
+import { basename, resolve } from "path";
+
+//
+
+const cwd = template(basename(resolve(__dirname, "..", "..")));
+
+test(
+  "app-ingress-annotations: kosko generate --preprod",
+  async () => {
+    const gitlabEnv = config({
+      path: resolve(cwd, "./environments/.gitlab-ci.env"),
+    }).parsed;
+
+    const env = {
+      ...gitlabEnv,
+      SOCIALGOUV_CONFIG_PATH: __dirname + "/config.json",
+    };
+
+    // Required to allow seemless integration code example
+    const result = await execa.node(
+      KOSKO_BIN,
+      ["generate", "--env", "preprod"],
+      { cwd, env }
+    );
+
+    expect(result.stdout).toMatchSnapshot();
+    expect(result.exitCode).toEqual(0);
+  },
+  TIMEOUT
+);

--- a/e2e/templates/autodevops/app-no-netpol/__tests__/kosko generate --env prod.ts
+++ b/e2e/templates/autodevops/app-no-netpol/__tests__/kosko generate --env prod.ts
@@ -1,0 +1,34 @@
+//
+
+import { config } from "dotenv";
+import { KOSKO_BIN, template, TIMEOUT } from "e2e/templates/helpers";
+import execa from "execa";
+import { basename, resolve } from "path";
+
+//
+
+const cwd = template(basename(resolve(__dirname, "..", "..")));
+
+test(
+  "app-ingress-annotations: kosko generate --prod",
+  async () => {
+    const gitlabEnv = config({
+      path: resolve(cwd, "./environments/.gitlab-ci.env"),
+    }).parsed;
+
+    const env = {
+      ...gitlabEnv,
+      SOCIALGOUV_CONFIG_PATH: __dirname + "/config.json",
+    };
+
+    // Required to allow seemless integration code example
+    const result = await execa.node(KOSKO_BIN, ["generate", "--env", "prod"], {
+      cwd,
+      env,
+    });
+
+    expect(result.stdout).toMatchSnapshot();
+    expect(result.exitCode).toEqual(0);
+  },
+  TIMEOUT
+);

--- a/e2e/templates/autodevops/app-pgHostDev/__tests__/__snapshots__/kosko generate --env dev.ts.snap
+++ b/e2e/templates/autodevops/app-pgHostDev/__tests__/__snapshots__/kosko generate --env dev.ts.snap
@@ -165,6 +165,27 @@ spec:
         - e2e-branch-42-sample-kosko.dev2.fabrique.social.gouv.fr
       secretName: wildcard-crt
 ---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: netpol-sample-kosko-24-e2e-branch-42
+  namespace: sample-kosko-24-e2e-branch-42
+spec:
+  ingress:
+    - from:
+        - podSelector: {}
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: ingress-controller
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: monitoring
+  podSelector: {}
+  policyTypes:
+    - Ingress
+---
 apiVersion: batch/v1
 kind: Job
 spec:

--- a/e2e/templates/autodevops/app-pgHostDev/__tests__/__snapshots__/kosko generate --env preprod.ts.snap
+++ b/e2e/templates/autodevops/app-pgHostDev/__tests__/__snapshots__/kosko generate --env preprod.ts.snap
@@ -165,6 +165,27 @@ spec:
         - e2e-branch-42-sample-kosko.dev2.fabrique.social.gouv.fr
       secretName: wildcard-crt
 ---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: netpol-sample-kosko-24-e2e-branch-42
+  namespace: sample-kosko-24-e2e-branch-42
+spec:
+  ingress:
+    - from:
+        - podSelector: {}
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: ingress-controller
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: monitoring
+  podSelector: {}
+  policyTypes:
+    - Ingress
+---
 apiVersion: batch/v1
 kind: Job
 spec:

--- a/e2e/templates/autodevops/app-pgHostDev/__tests__/__snapshots__/kosko generate --env prod.ts.snap
+++ b/e2e/templates/autodevops/app-pgHostDev/__tests__/__snapshots__/kosko generate --env prod.ts.snap
@@ -165,6 +165,27 @@ spec:
         - e2e-branch-42-sample-kosko.dev2.fabrique.social.gouv.fr
       secretName: wildcard-crt
 ---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: netpol-sample-kosko-24-e2e-branch-42
+  namespace: sample-kosko-24-e2e-branch-42
+spec:
+  ingress:
+    - from:
+        - podSelector: {}
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: ingress-controller
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: monitoring
+  podSelector: {}
+  policyTypes:
+    - Ingress
+---
 apiVersion: batch/v1
 kind: Job
 spec:

--- a/e2e/templates/autodevops/app/__tests__/__snapshots__/kosko generate --env dev.ts.snap
+++ b/e2e/templates/autodevops/app/__tests__/__snapshots__/kosko generate --env dev.ts.snap
@@ -143,5 +143,26 @@ spec:
   tls:
     - hosts:
         - e2e-branch-42-sample-kosko.dev2.fabrique.social.gouv.fr
-      secretName: wildcard-crt"
+      secretName: wildcard-crt
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: netpol-sample-kosko-24-e2e-branch-42
+  namespace: sample-kosko-24-e2e-branch-42
+spec:
+  ingress:
+    - from:
+        - podSelector: {}
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: ingress-controller
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: monitoring
+  podSelector: {}
+  policyTypes:
+    - Ingress"
 `;

--- a/e2e/templates/autodevops/app/__tests__/__snapshots__/kosko generate --env preprod.ts.snap
+++ b/e2e/templates/autodevops/app/__tests__/__snapshots__/kosko generate --env preprod.ts.snap
@@ -143,5 +143,26 @@ spec:
   tls:
     - hosts:
         - e2e-branch-42-sample-kosko.dev2.fabrique.social.gouv.fr
-      secretName: wildcard-crt"
+      secretName: wildcard-crt
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: netpol-sample-kosko-24-e2e-branch-42
+  namespace: sample-kosko-24-e2e-branch-42
+spec:
+  ingress:
+    - from:
+        - podSelector: {}
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: ingress-controller
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: monitoring
+  podSelector: {}
+  policyTypes:
+    - Ingress"
 `;

--- a/e2e/templates/autodevops/app/__tests__/__snapshots__/kosko generate --env prod.ts.snap
+++ b/e2e/templates/autodevops/app/__tests__/__snapshots__/kosko generate --env prod.ts.snap
@@ -143,5 +143,26 @@ spec:
   tls:
     - hosts:
         - e2e-branch-42-sample-kosko.dev2.fabrique.social.gouv.fr
-      secretName: wildcard-crt"
+      secretName: wildcard-crt
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: netpol-sample-kosko-24-e2e-branch-42
+  namespace: sample-kosko-24-e2e-branch-42
+spec:
+  ingress:
+    - from:
+        - podSelector: {}
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: ingress-controller
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: monitoring
+  podSelector: {}
+  policyTypes:
+    - Ingress"
 `;

--- a/e2e/templates/autodevops/azurepg/__tests__/__snapshots__/kosko generate --env dev.ts.snap
+++ b/e2e/templates/autodevops/azurepg/__tests__/__snapshots__/kosko generate --env dev.ts.snap
@@ -165,6 +165,27 @@ spec:
         - e2e-branch-42-sample-kosko.dev2.fabrique.social.gouv.fr
       secretName: wildcard-crt
 ---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: netpol-sample-kosko-24-e2e-branch-42
+  namespace: sample-kosko-24-e2e-branch-42
+spec:
+  ingress:
+    - from:
+        - podSelector: {}
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: ingress-controller
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: monitoring
+  podSelector: {}
+  policyTypes:
+    - Ingress
+---
 apiVersion: batch/v1
 kind: Job
 spec:

--- a/e2e/templates/autodevops/azurepg/__tests__/__snapshots__/kosko generate --env preprod.ts.snap
+++ b/e2e/templates/autodevops/azurepg/__tests__/__snapshots__/kosko generate --env preprod.ts.snap
@@ -163,5 +163,26 @@ spec:
   tls:
     - hosts:
         - preprod-sample-kosko.dev2.fabrique.social.gouv.fr
-      secretName: wildcard-crt"
+      secretName: wildcard-crt
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: netpol-sample-kosko-24-e2e-branch-42
+  namespace: sample-kosko-24-e2e-branch-42
+spec:
+  ingress:
+    - from:
+        - podSelector: {}
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: ingress-controller
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: monitoring
+  podSelector: {}
+  policyTypes:
+    - Ingress"
 `;

--- a/e2e/templates/autodevops/azurepg/__tests__/__snapshots__/kosko generate --env prod.ts.snap
+++ b/e2e/templates/autodevops/azurepg/__tests__/__snapshots__/kosko generate --env prod.ts.snap
@@ -165,5 +165,26 @@ spec:
   tls:
     - hosts:
         - sample-kosko.dev2.fabrique.social.gouv.fr
-      secretName: myapp-crt"
+      secretName: myapp-crt
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: netpol-sample-kosko
+  namespace: sample-kosko
+spec:
+  ingress:
+    - from:
+        - podSelector: {}
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: ingress-controller
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: monitoring
+  podSelector: {}
+  policyTypes:
+    - Ingress"
 `;

--- a/e2e/templates/autodevops/hasura/__tests__/__snapshots__/kosko generate --env dev.ts.snap
+++ b/e2e/templates/autodevops/hasura/__tests__/__snapshots__/kosko generate --env dev.ts.snap
@@ -281,7 +281,28 @@ spec:
       targetPort: 80
   selector:
     app: hasura
-  type: ClusterIP"
+  type: ClusterIP
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: netpol-sample-kosko-e2e-branch
+  namespace: sample-kosko-e2e-branch
+spec:
+  ingress:
+    - from:
+        - podSelector: {}
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: ingress-controller
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: monitoring
+  podSelector: {}
+  policyTypes:
+    - Ingress"
 `;
 
 exports[`hasura with ingress: kosko generate --dev 1`] = `
@@ -587,7 +608,28 @@ spec:
   tls:
     - hosts:
         - hasura-e2e-branch-42-sample-kosko.dev2.fabrique.social.gouv.fr
-      secretName: wildcard-crt"
+      secretName: wildcard-crt
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: netpol-sample-kosko-24-e2e-branch-42
+  namespace: sample-kosko-24-e2e-branch-42
+spec:
+  ingress:
+    - from:
+        - podSelector: {}
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: ingress-controller
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: monitoring
+  podSelector: {}
+  policyTypes:
+    - Ingress"
 `;
 
 exports[`hasura: kosko generate --dev 1`] = `
@@ -857,5 +899,26 @@ spec:
       targetPort: 80
   selector:
     app: hasura
-  type: ClusterIP"
+  type: ClusterIP
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: netpol-sample-kosko-24-e2e-branch-42
+  namespace: sample-kosko-24-e2e-branch-42
+spec:
+  ingress:
+    - from:
+        - podSelector: {}
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: ingress-controller
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: monitoring
+  podSelector: {}
+  policyTypes:
+    - Ingress"
 `;

--- a/e2e/templates/autodevops/hasura/__tests__/__snapshots__/kosko generate --env preprod.ts.snap
+++ b/e2e/templates/autodevops/hasura/__tests__/__snapshots__/kosko generate --env preprod.ts.snap
@@ -303,7 +303,28 @@ spec:
   tls:
     - hosts:
         - hasura-e2e-branch-42-sample-kosko.dev2.fabrique.social.gouv.fr
-      secretName: wildcard-crt"
+      secretName: wildcard-crt
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: netpol-sample-kosko-24-e2e-branch-42
+  namespace: sample-kosko-24-e2e-branch-42
+spec:
+  ingress:
+    - from:
+        - podSelector: {}
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: ingress-controller
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: monitoring
+  podSelector: {}
+  policyTypes:
+    - Ingress"
 `;
 
 exports[`hasura: kosko generate --preprod 1`] = `
@@ -573,5 +594,26 @@ spec:
       targetPort: 80
   selector:
     app: hasura
-  type: ClusterIP"
+  type: ClusterIP
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: netpol-sample-kosko-24-e2e-branch-42
+  namespace: sample-kosko-24-e2e-branch-42
+spec:
+  ingress:
+    - from:
+        - podSelector: {}
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: ingress-controller
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: monitoring
+  podSelector: {}
+  policyTypes:
+    - Ingress"
 `;

--- a/e2e/templates/autodevops/hasura/__tests__/__snapshots__/kosko generate --env prod.ts.snap
+++ b/e2e/templates/autodevops/hasura/__tests__/__snapshots__/kosko generate --env prod.ts.snap
@@ -303,7 +303,28 @@ spec:
   tls:
     - hosts:
         - hasura-e2e-branch-42-sample-kosko.dev2.fabrique.social.gouv.fr
-      secretName: wildcard-crt"
+      secretName: wildcard-crt
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: netpol-sample-kosko-24-e2e-branch-42
+  namespace: sample-kosko-24-e2e-branch-42
+spec:
+  ingress:
+    - from:
+        - podSelector: {}
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: ingress-controller
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: monitoring
+  podSelector: {}
+  policyTypes:
+    - Ingress"
 `;
 
 exports[`hasura: kosko generate --prod 1`] = `
@@ -573,5 +594,26 @@ spec:
       targetPort: 80
   selector:
     app: hasura
-  type: ClusterIP"
+  type: ClusterIP
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: netpol-sample-kosko-24-e2e-branch-42
+  namespace: sample-kosko-24-e2e-branch-42
+spec:
+  ingress:
+    - from:
+        - podSelector: {}
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: ingress-controller
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: monitoring
+  podSelector: {}
+  policyTypes:
+    - Ingress"
 `;

--- a/e2e/templates/autodevops/probes/__tests__/__snapshots__/kosko generate --env dev.ts.snap
+++ b/e2e/templates/autodevops/probes/__tests__/__snapshots__/kosko generate --env dev.ts.snap
@@ -144,5 +144,26 @@ spec:
   tls:
     - hosts:
         - e2e-branch-42-sample-kosko.dev2.fabrique.social.gouv.fr
-      secretName: wildcard-crt"
+      secretName: wildcard-crt
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: netpol-sample-kosko-24-e2e-branch-42
+  namespace: sample-kosko-24-e2e-branch-42
+spec:
+  ingress:
+    - from:
+        - podSelector: {}
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: ingress-controller
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: monitoring
+  podSelector: {}
+  policyTypes:
+    - Ingress"
 `;

--- a/e2e/templates/autodevops/probes/__tests__/__snapshots__/kosko generate --env preprod.ts.snap
+++ b/e2e/templates/autodevops/probes/__tests__/__snapshots__/kosko generate --env preprod.ts.snap
@@ -144,5 +144,26 @@ spec:
   tls:
     - hosts:
         - e2e-branch-42-sample-kosko.dev2.fabrique.social.gouv.fr
-      secretName: wildcard-crt"
+      secretName: wildcard-crt
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: netpol-sample-kosko-24-e2e-branch-42
+  namespace: sample-kosko-24-e2e-branch-42
+spec:
+  ingress:
+    - from:
+        - podSelector: {}
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: ingress-controller
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: monitoring
+  podSelector: {}
+  policyTypes:
+    - Ingress"
 `;

--- a/e2e/templates/autodevops/probes/__tests__/__snapshots__/kosko generate --env prod.ts.snap
+++ b/e2e/templates/autodevops/probes/__tests__/__snapshots__/kosko generate --env prod.ts.snap
@@ -144,5 +144,26 @@ spec:
   tls:
     - hosts:
         - e2e-branch-42-sample-kosko.dev2.fabrique.social.gouv.fr
-      secretName: wildcard-crt"
+      secretName: wildcard-crt
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: netpol-sample-kosko-24-e2e-branch-42
+  namespace: sample-kosko-24-e2e-branch-42
+spec:
+  ingress:
+    - from:
+        - podSelector: {}
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: ingress-controller
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: monitoring
+  podSelector: {}
+  policyTypes:
+    - Ingress"
 `;

--- a/e2e/templates/autodevops/probesPath/__tests__/__snapshots__/kosko generate --env dev.ts.snap
+++ b/e2e/templates/autodevops/probesPath/__tests__/__snapshots__/kosko generate --env dev.ts.snap
@@ -144,5 +144,26 @@ spec:
   tls:
     - hosts:
         - e2e-branch-42-sample-kosko.dev2.fabrique.social.gouv.fr
-      secretName: wildcard-crt"
+      secretName: wildcard-crt
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: netpol-sample-kosko-24-e2e-branch-42
+  namespace: sample-kosko-24-e2e-branch-42
+spec:
+  ingress:
+    - from:
+        - podSelector: {}
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: ingress-controller
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: monitoring
+  podSelector: {}
+  policyTypes:
+    - Ingress"
 `;

--- a/e2e/templates/autodevops/probesPath/__tests__/__snapshots__/kosko generate --env preprod.ts.snap
+++ b/e2e/templates/autodevops/probesPath/__tests__/__snapshots__/kosko generate --env preprod.ts.snap
@@ -144,5 +144,26 @@ spec:
   tls:
     - hosts:
         - e2e-branch-42-sample-kosko.dev2.fabrique.social.gouv.fr
-      secretName: wildcard-crt"
+      secretName: wildcard-crt
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: netpol-sample-kosko-24-e2e-branch-42
+  namespace: sample-kosko-24-e2e-branch-42
+spec:
+  ingress:
+    - from:
+        - podSelector: {}
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: ingress-controller
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: monitoring
+  podSelector: {}
+  policyTypes:
+    - Ingress"
 `;

--- a/e2e/templates/autodevops/probesPath/__tests__/__snapshots__/kosko generate --env prod.ts.snap
+++ b/e2e/templates/autodevops/probesPath/__tests__/__snapshots__/kosko generate --env prod.ts.snap
@@ -144,5 +144,26 @@ spec:
   tls:
     - hosts:
         - e2e-branch-42-sample-kosko.dev2.fabrique.social.gouv.fr
-      secretName: wildcard-crt"
+      secretName: wildcard-crt
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: netpol-sample-kosko-24-e2e-branch-42
+  namespace: sample-kosko-24-e2e-branch-42
+spec:
+  ingress:
+    - from:
+        - podSelector: {}
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: ingress-controller
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: monitoring
+  podSelector: {}
+  policyTypes:
+    - Ingress"
 `;

--- a/e2e/templates/autodevops/registry/__tests__/__snapshots__/kosko generate --env dev.ts.snap
+++ b/e2e/templates/autodevops/registry/__tests__/__snapshots__/kosko generate --env dev.ts.snap
@@ -151,7 +151,28 @@ spec:
   tls:
     - hosts:
         - sample-kosko-e2e-branch.dev2.fabrique.social.gouv.fr
-      secretName: wildcard-crt"
+      secretName: wildcard-crt
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: netpol-sample-kosko-e2e-branch
+  namespace: sample-kosko-e2e-branch
+spec:
+  ingress:
+    - from:
+        - podSelector: {}
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: ingress-controller
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: monitoring
+  podSelector: {}
+  policyTypes:
+    - Ingress"
 `;
 
 exports[`registry: kosko generate --dev 1`] = `
@@ -297,5 +318,26 @@ spec:
   tls:
     - hosts:
         - e2e-branch-42-sample-kosko.dev2.fabrique.social.gouv.fr
-      secretName: wildcard-crt"
+      secretName: wildcard-crt
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: netpol-sample-kosko-24-e2e-branch-42
+  namespace: sample-kosko-24-e2e-branch-42
+spec:
+  ingress:
+    - from:
+        - podSelector: {}
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: ingress-controller
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: monitoring
+  podSelector: {}
+  policyTypes:
+    - Ingress"
 `;

--- a/e2e/templates/autodevops/registry/__tests__/__snapshots__/kosko generate --env preprod.ts.snap
+++ b/e2e/templates/autodevops/registry/__tests__/__snapshots__/kosko generate --env preprod.ts.snap
@@ -143,5 +143,26 @@ spec:
   tls:
     - hosts:
         - e2e-branch-42-sample-kosko.dev2.fabrique.social.gouv.fr
-      secretName: wildcard-crt"
+      secretName: wildcard-crt
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: netpol-sample-kosko-24-e2e-branch-42
+  namespace: sample-kosko-24-e2e-branch-42
+spec:
+  ingress:
+    - from:
+        - podSelector: {}
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: ingress-controller
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: monitoring
+  podSelector: {}
+  policyTypes:
+    - Ingress"
 `;

--- a/e2e/templates/autodevops/registry/__tests__/__snapshots__/kosko generate --env prod.ts.snap
+++ b/e2e/templates/autodevops/registry/__tests__/__snapshots__/kosko generate --env prod.ts.snap
@@ -143,5 +143,26 @@ spec:
   tls:
     - hosts:
         - e2e-branch-42-sample-kosko.dev2.fabrique.social.gouv.fr
-      secretName: wildcard-crt"
+      secretName: wildcard-crt
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: netpol-sample-kosko-24-e2e-branch-42
+  namespace: sample-kosko-24-e2e-branch-42
+spec:
+  ingress:
+    - from:
+        - podSelector: {}
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: ingress-controller
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: monitoring
+  podSelector: {}
+  policyTypes:
+    - Ingress"
 `;

--- a/e2e/templates/autodevops/resources/__tests__/__snapshots__/kosko generate --env dev.ts.snap
+++ b/e2e/templates/autodevops/resources/__tests__/__snapshots__/kosko generate --env dev.ts.snap
@@ -143,5 +143,26 @@ spec:
   tls:
     - hosts:
         - e2e-branch-42-sample-kosko.dev2.fabrique.social.gouv.fr
-      secretName: wildcard-crt"
+      secretName: wildcard-crt
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: netpol-sample-kosko-24-e2e-branch-42
+  namespace: sample-kosko-24-e2e-branch-42
+spec:
+  ingress:
+    - from:
+        - podSelector: {}
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: ingress-controller
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: monitoring
+  podSelector: {}
+  policyTypes:
+    - Ingress"
 `;

--- a/e2e/templates/autodevops/resources/__tests__/__snapshots__/kosko generate --env preprod.ts.snap
+++ b/e2e/templates/autodevops/resources/__tests__/__snapshots__/kosko generate --env preprod.ts.snap
@@ -143,5 +143,26 @@ spec:
   tls:
     - hosts:
         - e2e-branch-42-sample-kosko.dev2.fabrique.social.gouv.fr
-      secretName: wildcard-crt"
+      secretName: wildcard-crt
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: netpol-sample-kosko-24-e2e-branch-42
+  namespace: sample-kosko-24-e2e-branch-42
+spec:
+  ingress:
+    - from:
+        - podSelector: {}
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: ingress-controller
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: monitoring
+  podSelector: {}
+  policyTypes:
+    - Ingress"
 `;

--- a/e2e/templates/autodevops/resources/__tests__/__snapshots__/kosko generate --env prod.ts.snap
+++ b/e2e/templates/autodevops/resources/__tests__/__snapshots__/kosko generate --env prod.ts.snap
@@ -143,5 +143,26 @@ spec:
   tls:
     - hosts:
         - e2e-branch-42-sample-kosko.dev2.fabrique.social.gouv.fr
-      secretName: wildcard-crt"
+      secretName: wildcard-crt
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: netpol-sample-kosko-24-e2e-branch-42
+  namespace: sample-kosko-24-e2e-branch-42
+spec:
+  ingress:
+    - from:
+        - podSelector: {}
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: ingress-controller
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: monitoring
+  podSelector: {}
+  policyTypes:
+    - Ingress"
 `;

--- a/e2e/templates/autodevops/static-ingress-anotations/__tests__/__snapshots__/kosko generate --env dev.ts.snap
+++ b/e2e/templates/autodevops/static-ingress-anotations/__tests__/__snapshots__/kosko generate --env dev.ts.snap
@@ -2,6 +2,27 @@
 
 exports[`static-ingress-anotations: kosko generate --dev 1`] = `
 "---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: netpol-sample-kosko-24-e2e-branch-42
+  namespace: sample-kosko-24-e2e-branch-42
+spec:
+  ingress:
+    - from:
+        - podSelector: {}
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: ingress-controller
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: monitoring
+  podSelector: {}
+  policyTypes:
+    - Ingress
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/e2e/templates/autodevops/static-ingress-anotations/__tests__/__snapshots__/kosko generate --env prod.ts.snap
+++ b/e2e/templates/autodevops/static-ingress-anotations/__tests__/__snapshots__/kosko generate --env prod.ts.snap
@@ -2,6 +2,27 @@
 
 exports[`static-ingress-anotations: kosko generate --prod 1`] = `
 "---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: netpol-sample-kosko-24-e2e-branch-42
+  namespace: sample-kosko-24-e2e-branch-42
+spec:
+  ingress:
+    - from:
+        - podSelector: {}
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: ingress-controller
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: monitoring
+  podSelector: {}
+  policyTypes:
+    - Ingress
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/e2e/templates/autodevops/static/__tests__/__snapshots__/kosko generate --env dev.ts.snap
+++ b/e2e/templates/autodevops/static/__tests__/__snapshots__/kosko generate --env dev.ts.snap
@@ -2,6 +2,27 @@
 
 exports[`static github: kosko generate --dev 1`] = `
 "---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: netpol-sample-kosko-e2e-branch
+  namespace: sample-kosko-e2e-branch
+spec:
+  ingress:
+    - from:
+        - podSelector: {}
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: ingress-controller
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: monitoring
+  podSelector: {}
+  policyTypes:
+    - Ingress
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -153,6 +174,27 @@ spec:
 
 exports[`static: kosko generate --dev 1`] = `
 "---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: netpol-sample-kosko-24-e2e-branch-42
+  namespace: sample-kosko-24-e2e-branch-42
+spec:
+  ingress:
+    - from:
+        - podSelector: {}
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: ingress-controller
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: monitoring
+  podSelector: {}
+  policyTypes:
+    - Ingress
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/e2e/templates/autodevops/static/__tests__/__snapshots__/kosko generate --env preprod.ts.snap
+++ b/e2e/templates/autodevops/static/__tests__/__snapshots__/kosko generate --env preprod.ts.snap
@@ -2,6 +2,27 @@
 
 exports[`static github: kosko generate --preprod 1`] = `
 "---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: netpol-sample-kosko-preprod
+  namespace: sample-kosko-preprod
+spec:
+  ingress:
+    - from:
+        - podSelector: {}
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: ingress-controller
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: monitoring
+  podSelector: {}
+  policyTypes:
+    - Ingress
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -153,6 +174,27 @@ spec:
 
 exports[`static: kosko generate --preprod 1`] = `
 "---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: netpol-sample-kosko-24-e2e-branch-42
+  namespace: sample-kosko-24-e2e-branch-42
+spec:
+  ingress:
+    - from:
+        - podSelector: {}
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: ingress-controller
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: monitoring
+  podSelector: {}
+  policyTypes:
+    - Ingress
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/e2e/templates/autodevops/static/__tests__/__snapshots__/kosko generate --env prod.ts.snap
+++ b/e2e/templates/autodevops/static/__tests__/__snapshots__/kosko generate --env prod.ts.snap
@@ -2,6 +2,27 @@
 
 exports[`static github: kosko generate --prod 1`] = `
 "---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: netpol-sample-kosko
+  namespace: sample-kosko
+spec:
+  ingress:
+    - from:
+        - podSelector: {}
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: ingress-controller
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: monitoring
+  podSelector: {}
+  policyTypes:
+    - Ingress
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -151,6 +172,27 @@ spec:
 
 exports[`static: kosko generate --prod 1`] = `
 "---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: netpol-sample-kosko-24-e2e-branch-42
+  namespace: sample-kosko-24-e2e-branch-42
+spec:
+  ingress:
+    - from:
+        - podSelector: {}
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: ingress-controller
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: monitoring
+  podSelector: {}
+  policyTypes:
+    - Ingress
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/e2e/templates/autodevops/static/__tests__/__snapshots__/kosko generate tag --env dev.ts.snap
+++ b/e2e/templates/autodevops/static/__tests__/__snapshots__/kosko generate tag --env dev.ts.snap
@@ -2,6 +2,27 @@
 
 exports[`github tag: kosko generate --dev 1`] = `
 "---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: netpol-sample-kosko-v1-4-2-2bf7nu
+  namespace: sample-kosko-v1-4-2-2bf7nu
+spec:
+  ingress:
+    - from:
+        - podSelector: {}
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: ingress-controller
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: monitoring
+  podSelector: {}
+  policyTypes:
+    - Ingress
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/e2e/templates/autodevops/subdomain/__tests__/__snapshots__/kosko generate --env dev.ts.snap
+++ b/e2e/templates/autodevops/subdomain/__tests__/__snapshots__/kosko generate --env dev.ts.snap
@@ -2,6 +2,27 @@
 
 exports[`subdomain: kosko generate --dev 1`] = `
 "---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: netpol-sample-kosko-24-e2e-branch-42
+  namespace: sample-kosko-24-e2e-branch-42
+spec:
+  ingress:
+    - from:
+        - podSelector: {}
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: ingress-controller
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: monitoring
+  podSelector: {}
+  policyTypes:
+    - Ingress
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/e2e/templates/autodevops/subdomain/__tests__/__snapshots__/kosko generate --env preprod.ts.snap
+++ b/e2e/templates/autodevops/subdomain/__tests__/__snapshots__/kosko generate --env preprod.ts.snap
@@ -2,6 +2,27 @@
 
 exports[`subdomain: kosko generate --preprod 1`] = `
 "---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: netpol-sample-kosko-24-e2e-branch-42
+  namespace: sample-kosko-24-e2e-branch-42
+spec:
+  ingress:
+    - from:
+        - podSelector: {}
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: ingress-controller
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: monitoring
+  podSelector: {}
+  policyTypes:
+    - Ingress
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/e2e/templates/autodevops/subdomain/__tests__/__snapshots__/kosko generate --env prod.ts.snap
+++ b/e2e/templates/autodevops/subdomain/__tests__/__snapshots__/kosko generate --env prod.ts.snap
@@ -2,6 +2,27 @@
 
 exports[`subdomain: kosko generate --prod 1`] = `
 "---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: netpol-sample-kosko-24-e2e-branch-42
+  namespace: sample-kosko-24-e2e-branch-42
+spec:
+  ingress:
+    - from:
+        - podSelector: {}
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: ingress-controller
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: monitoring
+  podSelector: {}
+  policyTypes:
+    - Ingress
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/e2e/templates/autodevops/yaml/__tests__/__snapshots__/kosko generate --env dev.ts.snap
+++ b/e2e/templates/autodevops/yaml/__tests__/__snapshots__/kosko generate --env dev.ts.snap
@@ -145,6 +145,27 @@ spec:
         - e2e-branch-42-sample-kosko.dev2.fabrique.social.gouv.fr
       secretName: wildcard-crt
 ---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: netpol-sample-kosko-24-e2e-branch-42
+  namespace: sample-kosko-24-e2e-branch-42
+spec:
+  ingress:
+    - from:
+        - podSelector: {}
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: ingress-controller
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: monitoring
+  podSelector: {}
+  policyTypes:
+    - Ingress
+---
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:

--- a/e2e/templates/autodevops/yaml/__tests__/__snapshots__/kosko generate --env preprod.ts.snap
+++ b/e2e/templates/autodevops/yaml/__tests__/__snapshots__/kosko generate --env preprod.ts.snap
@@ -145,6 +145,27 @@ spec:
         - e2e-branch-42-sample-kosko.dev2.fabrique.social.gouv.fr
       secretName: wildcard-crt
 ---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: netpol-sample-kosko-24-e2e-branch-42
+  namespace: sample-kosko-24-e2e-branch-42
+spec:
+  ingress:
+    - from:
+        - podSelector: {}
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: ingress-controller
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: monitoring
+  podSelector: {}
+  policyTypes:
+    - Ingress
+---
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:

--- a/e2e/templates/autodevops/yaml/__tests__/__snapshots__/kosko generate --env prod.ts.snap
+++ b/e2e/templates/autodevops/yaml/__tests__/__snapshots__/kosko generate --env prod.ts.snap
@@ -145,6 +145,27 @@ spec:
         - e2e-branch-42-sample-kosko.dev2.fabrique.social.gouv.fr
       secretName: wildcard-crt
 ---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: netpol-sample-kosko-24-e2e-branch-42
+  namespace: sample-kosko-24-e2e-branch-42
+spec:
+  ingress:
+    - from:
+        - podSelector: {}
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: ingress-controller
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: monitoring
+  podSelector: {}
+  policyTypes:
+    - Ingress
+---
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:

--- a/templates/autodevops/components/netpol.ts
+++ b/templates/autodevops/components/netpol.ts
@@ -1,0 +1,10 @@
+import { create } from "@socialgouv/kosko-charts/components/netpol";
+import Config from "../utils/config";
+
+const manifests = async () => {
+  const { netpol } = await Config();
+  if (netpol === false) return [];
+  return create();
+};
+
+export default manifests;

--- a/templates/autodevops/components/netpol.ts
+++ b/templates/autodevops/components/netpol.ts
@@ -1,4 +1,5 @@
 import { create } from "@socialgouv/kosko-charts/components/netpol";
+
 import Config from "../utils/config";
 
 const manifests = async () => {

--- a/templates/autodevops/utils/config.ts
+++ b/templates/autodevops/utils/config.ts
@@ -9,20 +9,34 @@ interface Probes {
 
 interface ConfigTypes {
   name: string;
+  /** app or static */
   type: string;
+  /** force deployment sudomain */
   subdomain: string;
+  /** deploy an hasura backend */
   hasura?: boolean | "exposed";
+  /** enable azure-pg : wait-pg initContainer and secrets */
   azurepg?: boolean;
+  /** define a custom pgHost for development */
   pgHostDev?: string;
+  /** redefines k8s probes */
   probes?: Probes;
+  /** redefines k8s resources */
   resources?: IIoK8sApiCoreV1ResourceRequirements;
+  /** redefines default probes path (/healthz) */
   probesPath?: string;
+  /** override ingress annotations */
   ingress?: {
     annotations?: Record<string, string>;
   };
+  /** ghcr or harbor */
   registry?: string;
+  /** project name */
   project?: string;
+
   restoreDb?: string;
+  /** set to false to deisable default network policy */
+  netpol?: boolean;
 }
 
 const Config = async (): Promise<ConfigTypes> => {


### PR DESCRIPTION
enable a default NetworkPolicy in the autodevops template.

This prevent incoming network requests except :

 - from same namespace
 - ingress
 - prometheus monitoring

use `netpol: false` in config.json to disable it