### PR TITLE
feat: add oauth2-proxy component

### DIFF
--- a/src/components/oauth2-proxy/README.md
+++ b/src/components/oauth2-proxy/README.md
@@ -1,0 +1,36 @@
+# oauth2-proxy
+
+Add a [oauth2-proxy](https://oauth2-proxy.github.io/oauth2-proxy/) instance in front of your application.
+
+## Usage
+
+`components/oauth2-proxy.ts` :
+
+This creates an oauth2-proxy to http://app:80
+
+```js
+import { create } from "@socialgouv/kosko-charts/components/oauth2-proxy";
+
+const manifests = create({
+  upstream: "http://app:80",
+});
+
+export default manifests;
+```
+
+:warning: Be sure to disable your main application ingress so the proxy can handle it.
+
+## Requirements
+
+The secrets and configuration should reside in :
+
+- `environments/[env]/oauth2-proxy-configmap.yml`
+- `environments/[env]/oauth2-proxy-sealed-secret.yml`
+
+### `oauth2-proxy-configmap.yml`
+
+Define public environment variables from https://oauth2-proxy.github.io/oauth2-proxy/docs/configuration/overview
+
+### `oauth2-proxy-sealed-secret.yml`
+
+Define secret environment variables from https://oauth2-proxy.github.io/oauth2-proxy/docs/configuration/overview

--- a/src/components/oauth2-proxy/__snapshots__/index.test.ts.snap
+++ b/src/components/oauth2-proxy/__snapshots__/index.test.ts.snap
@@ -1,0 +1,252 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should return dev manifests 1`] = `
+Array [
+  Object {
+    "apiVersion": "v1",
+    "kind": "ConfigMap",
+    "metadata": Object {
+      "name": "some-config-map",
+      "namespace": "test-456",
+    },
+  },
+  Object {
+    "apiVersion": "bitnami.com/v1alpha1",
+    "kind": "SealedSecret",
+    "metadata": Object {
+      "name": "some-sealed-secret",
+      "namespace": "test-456",
+    },
+  },
+  Array [
+    Object {
+      "apiVersion": "apps/v1",
+      "kind": "Deployment",
+      "metadata": Object {
+        "annotations": Object {
+          "app.github.com/job": "777",
+          "app.github.com/ref": "456",
+          "app.github.com/repo": "socialgouv/test",
+          "app.github.com/run": "888",
+          "app.github.com/sha": "123",
+          "kapp.k14s.io/disable-default-label-scoping-rules": "",
+          "kapp.k14s.io/disable-default-ownership-label-rules": "",
+        },
+        "labels": Object {
+          "app": "proxy",
+          "application": "test",
+          "cert": "wildcard",
+          "component": "test",
+          "owner": "test",
+          "team": "test",
+        },
+        "name": "proxy",
+        "namespace": "test-456",
+      },
+      "spec": Object {
+        "replicas": 1,
+        "selector": Object {
+          "matchLabels": Object {
+            "app": "proxy",
+          },
+        },
+        "template": Object {
+          "metadata": Object {
+            "annotations": Object {
+              "app.github.com/job": "777",
+              "app.github.com/ref": "456",
+              "app.github.com/repo": "socialgouv/test",
+              "app.github.com/run": "888",
+              "app.github.com/sha": "123",
+              "kapp.k14s.io/disable-default-label-scoping-rules": "",
+              "kapp.k14s.io/disable-default-ownership-label-rules": "",
+            },
+            "labels": Object {
+              "app": "proxy",
+              "application": "test",
+              "cert": "wildcard",
+              "component": "test",
+              "owner": "test",
+              "team": "test",
+            },
+          },
+          "spec": Object {
+            "containers": Array [
+              Object {
+                "args": Array [
+                  "--upstream",
+                  "http://target:123",
+                ],
+                "env": Array [
+                  Object {
+                    "name": "OAUTH2_PROXY_HTTP_ADDRESS",
+                    "value": "0.0.0.0:4180",
+                  },
+                  Object {
+                    "name": "OAUTH2_PROXY_REDIRECT_URL",
+                    "value": "https://test-456.fabrique.social.gouv.fr/oauth2/callback",
+                  },
+                ],
+                "envFrom": Array [
+                  Object {
+                    "configMapRef": Object {
+                      "name": "some-config-map",
+                    },
+                  },
+                  Object {
+                    "secretRef": Object {
+                      "name": "some-sealed-secret",
+                    },
+                  },
+                ],
+                "image": "quay.io/oauth2-proxy/oauth2-proxy:v7.2.0",
+                "livenessProbe": Object {
+                  "failureThreshold": 6,
+                  "httpGet": Object {
+                    "path": "/ping",
+                    "port": "http",
+                  },
+                  "initialDelaySeconds": 30,
+                  "periodSeconds": 5,
+                  "timeoutSeconds": 5,
+                },
+                "name": "proxy",
+                "ports": Array [
+                  Object {
+                    "containerPort": 4180,
+                    "name": "http",
+                  },
+                ],
+                "readinessProbe": Object {
+                  "failureThreshold": 15,
+                  "httpGet": Object {
+                    "path": "/ping",
+                    "port": "http",
+                  },
+                  "initialDelaySeconds": 0,
+                  "periodSeconds": 5,
+                  "successThreshold": 1,
+                  "timeoutSeconds": 1,
+                },
+                "resources": Object {
+                  "limits": Object {
+                    "cpu": "500m",
+                    "memory": "128Mi",
+                  },
+                  "requests": Object {
+                    "cpu": "5m",
+                    "memory": "16Mi",
+                  },
+                },
+                "startupProbe": Object {
+                  "failureThreshold": 12,
+                  "httpGet": Object {
+                    "path": "/ping",
+                    "port": "http",
+                  },
+                  "periodSeconds": 5,
+                },
+              },
+            ],
+          },
+        },
+      },
+    },
+    Object {
+      "apiVersion": "v1",
+      "kind": "Service",
+      "metadata": Object {
+        "annotations": Object {
+          "app.github.com/job": "777",
+          "app.github.com/ref": "456",
+          "app.github.com/repo": "socialgouv/test",
+          "app.github.com/run": "888",
+          "app.github.com/sha": "123",
+          "kapp.k14s.io/disable-default-label-scoping-rules": "",
+          "kapp.k14s.io/disable-default-ownership-label-rules": "",
+        },
+        "labels": Object {
+          "app": "proxy",
+          "application": "test",
+          "cert": "wildcard",
+          "component": "test",
+          "owner": "test",
+          "team": "test",
+        },
+        "name": "proxy",
+        "namespace": "test-456",
+      },
+      "spec": Object {
+        "ports": Array [
+          Object {
+            "name": "http",
+            "port": 80,
+            "targetPort": 4180,
+          },
+        ],
+        "selector": Object {
+          "app": "proxy",
+        },
+        "type": "ClusterIP",
+      },
+    },
+    Object {
+      "apiVersion": "networking.k8s.io/v1",
+      "kind": "Ingress",
+      "metadata": Object {
+        "annotations": Object {
+          "app.github.com/job": "777",
+          "app.github.com/ref": "456",
+          "app.github.com/repo": "socialgouv/test",
+          "app.github.com/run": "888",
+          "app.github.com/sha": "123",
+          "kapp.k14s.io/disable-default-label-scoping-rules": "",
+          "kapp.k14s.io/disable-default-ownership-label-rules": "",
+          "kubernetes.io/ingress.class": "nginx",
+        },
+        "labels": Object {
+          "app": "proxy",
+          "application": "test",
+          "cert": "wildcard",
+          "component": "test",
+          "owner": "test",
+          "team": "test",
+        },
+        "name": "proxy",
+        "namespace": "test-456",
+      },
+      "spec": Object {
+        "rules": Array [
+          Object {
+            "host": "test-456.fabrique.social.gouv.fr",
+            "http": Object {
+              "paths": Array [
+                Object {
+                  "backend": Object {
+                    "service": Object {
+                      "name": "proxy",
+                      "port": Object {
+                        "name": "http",
+                      },
+                    },
+                  },
+                  "path": "/",
+                  "pathType": "Prefix",
+                },
+              ],
+            },
+          },
+        ],
+        "tls": Array [
+          Object {
+            "hosts": Array [
+              "test-456.fabrique.social.gouv.fr",
+            ],
+            "secretName": "wildcard-crt",
+          },
+        ],
+      },
+    },
+  ],
+]
+`;

--- a/src/components/oauth2-proxy/index.test.ts
+++ b/src/components/oauth2-proxy/index.test.ts
@@ -1,7 +1,4 @@
-import { createNodeCJSEnvironment } from "@kosko/env";
 import environmentMock from "@socialgouv/kosko-charts/environments/index.mock";
-
-import { directory } from "tempy";
 
 import { create } from "./index";
 import { ConfigMap } from "kubernetes-models/v1";
@@ -39,13 +36,8 @@ test("should return dev manifests", async () => {
 
   jest.doMock("@socialgouv/kosko-charts/environments", () => environmentMock);
 
-  const mockCwd = directory();
-  const mockEnv = createNodeCJSEnvironment({ cwd: mockCwd });
-  mockEnv.env = "dev";
-
   const manifests = await create({
     upstream: "http://target:123",
-    env: mockEnv,
   });
   expect(manifests).toMatchSnapshot();
 });

--- a/src/components/oauth2-proxy/index.test.ts
+++ b/src/components/oauth2-proxy/index.test.ts
@@ -1,0 +1,51 @@
+import { createNodeCJSEnvironment } from "@kosko/env";
+import environmentMock from "@socialgouv/kosko-charts/environments/index.mock";
+
+import { directory } from "tempy";
+
+import { create } from "./index";
+import { ConfigMap } from "kubernetes-models/v1";
+import { SealedSecret } from "@kubernetes-models/sealed-secrets/bitnami.com/v1alpha1";
+
+const mockConfigMap = new ConfigMap({
+  metadata: { name: "some-config-map" },
+});
+const mockSealedSecret = new SealedSecret({
+  metadata: { name: "some-sealed-secret" },
+});
+
+jest.mock("@kosko/yaml", () => {
+  return {
+    loadFile:
+      (path: any, { transform }: any) =>
+      () => {
+        if (path.match(/configmap.yml$/)) {
+          return [transform(mockConfigMap)];
+        } else if (path.match(/sealed-secret.yml$/)) {
+          return [transform(mockSealedSecret)];
+        }
+        return null;
+      },
+  };
+});
+
+test("should return dev manifests", async () => {
+  process.env.GITHUB_SHA = "123";
+  process.env.GITHUB_REF = "456";
+  process.env.GITHUB_JOB = "777";
+  process.env.GITHUB_RUN_ID = "888";
+  process.env.GITHUB_REPOSITORY = "socialgouv/test";
+  process.env.SOCIALGOUV_BASE_DOMAIN = "fabrique.social.gouv.fr";
+
+  jest.doMock("@socialgouv/kosko-charts/environments", () => environmentMock);
+
+  const mockCwd = directory();
+  const mockEnv = createNodeCJSEnvironment({ cwd: mockCwd });
+  mockEnv.env = "dev";
+
+  const manifests = await create({
+    upstream: "http://target:123",
+    env: mockEnv,
+  });
+  expect(manifests).toMatchSnapshot();
+});

--- a/src/components/oauth2-proxy/index.test.ts
+++ b/src/components/oauth2-proxy/index.test.ts
@@ -1,8 +1,9 @@
+import { SealedSecret } from "@kubernetes-models/sealed-secrets/bitnami.com/v1alpha1";
 import environmentMock from "@socialgouv/kosko-charts/environments/index.mock";
+import { ConfigMap } from "kubernetes-models/v1";
+import type { Manifest } from "templates/autodevops/types/config";
 
 import { create } from "./index";
-import { ConfigMap } from "kubernetes-models/v1";
-import { SealedSecret } from "@kubernetes-models/sealed-secrets/bitnami.com/v1alpha1";
 
 const mockConfigMap = new ConfigMap({
   metadata: { name: "some-config-map" },
@@ -14,12 +15,12 @@ const mockSealedSecret = new SealedSecret({
 jest.mock("@kosko/yaml", () => {
   return {
     loadFile:
-      (path: any, { transform }: any) =>
-      () => {
-        if (path.match(/configmap.yml$/)) {
-          return [transform(mockConfigMap)];
-        } else if (path.match(/sealed-secret.yml$/)) {
-          return [transform(mockSealedSecret)];
+      (path: string, { transform }) =>
+      (): Manifest[] | null => {
+        if (/configmap.yml$/.exec(path)) {
+          return [transform(mockConfigMap)] as Manifest[];
+        } else if (/sealed-secret.yml$/.exec(path)) {
+          return [transform(mockSealedSecret)] as Manifest[];
         }
         return null;
       },

--- a/src/components/oauth2-proxy/index.ts
+++ b/src/components/oauth2-proxy/index.ts
@@ -1,0 +1,110 @@
+import path from "path";
+import { Environment } from "@kosko/env";
+import { ConfigMap, EnvVar } from "kubernetes-models/v1";
+import { loadFile } from "@kosko/yaml";
+import { SealedSecret } from "@kubernetes-models/sealed-secrets/bitnami.com/v1alpha1";
+
+import { addEnv, getDeployment, getIngressHost } from "../..//utils";
+import environments from "../../environments";
+import { create as appCreate } from "../app";
+
+interface ProxyParams {
+  upstream: string;
+  env: Environment;
+}
+
+// load some YAML from user env
+const loadEnvYaml = async (fileName: string, env: Environment) => {
+  console.log(env.cwd);
+  console.log(path.join(env.cwd, `environments/${env.env}/${fileName}`));
+  return (
+    await loadFile(path.join(env.cwd, `environments/${env.env}/${fileName}`), {
+      transform: (manifest: any) => {
+        console.log("transform", manifest);
+        // force fix namespace
+        const ciEnv = environments(process.env);
+        if (manifest.metadata) {
+          manifest.metadata.namespace = ciEnv.metadata.namespace.name;
+        }
+        return manifest;
+      },
+    })()
+  )[0];
+};
+
+/*
+create an oauth-proxy deployment+service+ingress
+
+expect these files :
+ - environments/[env]/oauth2-proxy-configmap.yaml
+ - environments/[env]/oauth2-proxy-sealed-secret.yaml
+*/
+export const create = async ({ upstream, env }: ProxyParams) => {
+  // expect dedicated configmap
+  const configMap = (await loadEnvYaml(
+    "oauth2-proxy-configmap.yml",
+    env
+  )) as ConfigMap;
+  // expect dedicated secret
+  const sealedSecret = (await loadEnvYaml(
+    "oauth2-proxy-sealed-secret.yml",
+    env
+  )) as SealedSecret;
+
+  const manifests = await appCreate("proxy", {
+    env,
+    config: {
+      image: "quay.io/oauth2-proxy/oauth2-proxy:v7.2.0",
+      containerPort: 4180,
+      container: {
+        startupProbe: {
+          httpGet: {
+            path: "/ping",
+            port: "http",
+          },
+        },
+        livenessProbe: {
+          httpGet: {
+            path: "/ping",
+            port: "http",
+          },
+        },
+        readinessProbe: {
+          httpGet: {
+            path: "/ping",
+            port: "http",
+          },
+        },
+        args: ["--upstream", upstream],
+        env: [
+          new EnvVar({
+            name: "OAUTH2_PROXY_HTTP_ADDRESS",
+            value: "0.0.0.0:4180",
+          }),
+        ],
+        envFrom: [
+          {
+            configMapRef: { name: configMap?.metadata?.name },
+          },
+          {
+            secretRef: { name: sealedSecret?.metadata?.name },
+          },
+        ],
+      },
+    },
+  });
+
+  const deployment = getDeployment(manifests);
+  const hostName = getIngressHost(manifests);
+
+  // TODO: has no effect with github
+  addEnv({
+    deployment,
+    data: new EnvVar({
+      name: "OAUTH2_PROXY_REDIRECT_URL",
+      value: `https://${hostName}/oauth2/callback`,
+    }),
+  });
+
+  return [configMap, sealedSecret, manifests];
+};

--- a/src/components/oauth2-proxy/index.ts
+++ b/src/components/oauth2-proxy/index.ts
@@ -13,6 +13,9 @@ interface ProxyParams {
   upstream: string;
 }
 
+// renovate: datasource=docker depName=sosedoff/pgweb versioning=v7.2.0
+const OAUTH2_PROXY_VERSION = "v7.2.0";
+
 // load some YAML from user env
 const loadEnvYaml = async (fileName: string) => {
   return (
@@ -87,7 +90,7 @@ export const create = async ({ upstream }: ProxyParams) => {
         },
       },
       containerPort: 4180,
-      image: "quay.io/oauth2-proxy/oauth2-proxy:v7.2.0",
+      image: `quay.io/oauth2-proxy/oauth2-proxy:${OAUTH2_PROXY_VERSION}`,
     },
     env: koskoEnv,
   });


### PR DESCRIPTION
Add basic [oauth2-proxy](http://oauth2-proxy.github.io/oauth2-proxy/) component

The component expect these 2 files to exist : 
- `environments/[env]/oauth2-proxy-configmap.yml`
- `environments/[env]/oauth2-proxy-sealed-secret.yml`