### PR TITLE
feat(autodevops): add config.pg

### DIFF
--- a/e2e/templates/autodevops/pg/__tests__/__snapshots__/kosko generate --env dev.ts.snap
+++ b/e2e/templates/autodevops/pg/__tests__/__snapshots__/kosko generate --env dev.ts.snap
@@ -1,0 +1,194 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`azurepg: kosko generate --dev 1`] = `
+"---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kapp.k14s.io/disable-default-ownership-label-rules: ''
+    kapp.k14s.io/disable-default-label-scoping-rules: ''
+    kapp.k14s.io/delete-strategy: orphan
+    app.gitlab.com/app: socialgouv-sample-kosko
+    app.gitlab.com/env: e2e-branch-42
+    app.gitlab.com/env.name: e2e-branch-dev2
+  labels:
+    app: myapp
+    application: e2e-branch-42-sample-kosko
+    component: e2e-branch-42-sample-kosko
+    owner: sample-kosko
+    team: sample-kosko
+    cert: wildcard
+  name: myapp
+  namespace: sample-kosko-24-e2e-branch-42
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: myapp
+  template:
+    metadata:
+      annotations:
+        kapp.k14s.io/disable-default-ownership-label-rules: ''
+        kapp.k14s.io/disable-default-label-scoping-rules: ''
+        kapp.k14s.io/delete-strategy: orphan
+        app.gitlab.com/app: socialgouv-sample-kosko
+        app.gitlab.com/env: e2e-branch-42
+        app.gitlab.com/env.name: e2e-branch-dev2
+      labels:
+        app: myapp
+        application: e2e-branch-42-sample-kosko
+        component: e2e-branch-42-sample-kosko
+        owner: sample-kosko
+        team: sample-kosko
+        cert: wildcard
+    spec:
+      containers:
+        - image: >-
+            harbor.fabrique.social.gouv.fr/undefined/myapp:8843083edb7f873cad1d1420731a60773594ffae
+          livenessProbe:
+            failureThreshold: 6
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 5
+            timeoutSeconds: 5
+          name: myapp
+          ports:
+            - containerPort: 3000
+              name: http
+          readinessProbe:
+            failureThreshold: 15
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 0
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 200m
+              memory: 256Mi
+            requests:
+              cpu: 50m
+              memory: 128Mi
+          startupProbe:
+            failureThreshold: 12
+            httpGet:
+              path: /healthz
+              port: http
+            periodSeconds: 5
+          envFrom:
+            - secretRef:
+                name: some-pg-prefix-e2e-branch
+          env:
+            - name: APP_BASE_URL
+              value: https://e2e-branch-42-sample-kosko.dev2.fabrique.social.gouv.fr
+            - name: NEXTAUTH_URL
+              value: https://e2e-branch-42-sample-kosko.dev2.fabrique.social.gouv.fr
+      initContainers:
+        - env:
+            - name: WAIT_FOR_RETRIES
+              value: '24'
+          envFrom:
+            - secretRef:
+                name: some-pg-prefix-e2e-branch
+          image: ghcr.io/socialgouv/docker/wait-for-postgres:6.56.1
+          imagePullPolicy: Always
+          name: wait-for-postgres
+          resources:
+            limits:
+              cpu: 20m
+              memory: 32Mi
+            requests:
+              cpu: 5m
+              memory: 16Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: myapp
+    application: e2e-branch-42-sample-kosko
+    component: e2e-branch-42-sample-kosko
+    owner: sample-kosko
+    team: sample-kosko
+    cert: wildcard
+  name: myapp
+  annotations:
+    kapp.k14s.io/disable-default-ownership-label-rules: ''
+    kapp.k14s.io/disable-default-label-scoping-rules: ''
+    kapp.k14s.io/delete-strategy: orphan
+    app.gitlab.com/app: socialgouv-sample-kosko
+    app.gitlab.com/env: e2e-branch-42
+    app.gitlab.com/env.name: e2e-branch-dev2
+  namespace: sample-kosko-24-e2e-branch-42
+spec:
+  ports:
+    - name: http
+      port: 80
+      targetPort: 3000
+  selector:
+    app: myapp
+  type: ClusterIP
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    kapp.k14s.io/disable-default-ownership-label-rules: ''
+    kapp.k14s.io/disable-default-label-scoping-rules: ''
+    kapp.k14s.io/delete-strategy: orphan
+    app.gitlab.com/app: socialgouv-sample-kosko
+    app.gitlab.com/env: e2e-branch-42
+    app.gitlab.com/env.name: e2e-branch-dev2
+  labels:
+    app: myapp
+    application: e2e-branch-42-sample-kosko
+    component: e2e-branch-42-sample-kosko
+    owner: sample-kosko
+    team: sample-kosko
+    cert: wildcard
+  name: myapp
+  namespace: sample-kosko-24-e2e-branch-42
+spec:
+  rules:
+    - host: e2e-branch-42-sample-kosko.dev2.fabrique.social.gouv.fr
+      http:
+        paths:
+          - backend:
+              service:
+                name: myapp
+                port:
+                  name: http
+            path: /
+            pathType: Prefix
+  tls:
+    - hosts:
+        - e2e-branch-42-sample-kosko.dev2.fabrique.social.gouv.fr
+      secretName: wildcard-crt
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: netpol-sample-kosko-24-e2e-branch-42
+  namespace: sample-kosko-24-e2e-branch-42
+spec:
+  ingress:
+    - from:
+        - podSelector: {}
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: ingress-controller
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: monitoring
+  podSelector: {}
+  policyTypes:
+    - Ingress"
+`;

--- a/e2e/templates/autodevops/pg/__tests__/__snapshots__/kosko generate --env preprod.ts.snap
+++ b/e2e/templates/autodevops/pg/__tests__/__snapshots__/kosko generate --env preprod.ts.snap
@@ -1,0 +1,194 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`azurepg: kosko generate --preprod 1`] = `
+"---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kapp.k14s.io/disable-default-ownership-label-rules: ''
+    kapp.k14s.io/disable-default-label-scoping-rules: ''
+    kapp.k14s.io/delete-strategy: orphan
+    app.gitlab.com/app: socialgouv-sample-kosko
+    app.gitlab.com/env: e2e-branch-42
+    app.gitlab.com/env.name: preprod-dev2
+  labels:
+    app: myapp
+    application: e2e-branch-42-sample-kosko
+    component: e2e-branch-42-sample-kosko
+    owner: sample-kosko
+    team: sample-kosko
+    cert: wildcard
+  name: myapp
+  namespace: sample-kosko-24-e2e-branch-42
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: myapp
+  template:
+    metadata:
+      annotations:
+        kapp.k14s.io/disable-default-ownership-label-rules: ''
+        kapp.k14s.io/disable-default-label-scoping-rules: ''
+        kapp.k14s.io/delete-strategy: orphan
+        app.gitlab.com/app: socialgouv-sample-kosko
+        app.gitlab.com/env: e2e-branch-42
+        app.gitlab.com/env.name: preprod-dev2
+      labels:
+        app: myapp
+        application: e2e-branch-42-sample-kosko
+        component: e2e-branch-42-sample-kosko
+        owner: sample-kosko
+        team: sample-kosko
+        cert: wildcard
+    spec:
+      containers:
+        - image: >-
+            harbor.fabrique.social.gouv.fr/undefined/myapp:8843083edb7f873cad1d1420731a60773594ffae
+          livenessProbe:
+            failureThreshold: 6
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 5
+            timeoutSeconds: 5
+          name: myapp
+          ports:
+            - containerPort: 3000
+              name: http
+          readinessProbe:
+            failureThreshold: 15
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 0
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 200m
+              memory: 256Mi
+            requests:
+              cpu: 50m
+              memory: 128Mi
+          startupProbe:
+            failureThreshold: 12
+            httpGet:
+              path: /healthz
+              port: http
+            periodSeconds: 5
+          envFrom:
+            - secretRef:
+                name: some-pg-prefix
+          env:
+            - name: APP_BASE_URL
+              value: https://preprod-sample-kosko.dev2.fabrique.social.gouv.fr
+            - name: NEXTAUTH_URL
+              value: https://preprod-sample-kosko.dev2.fabrique.social.gouv.fr
+      initContainers:
+        - env:
+            - name: WAIT_FOR_RETRIES
+              value: '24'
+          envFrom:
+            - secretRef:
+                name: some-pg-prefix
+          image: ghcr.io/socialgouv/docker/wait-for-postgres:6.56.1
+          imagePullPolicy: Always
+          name: wait-for-postgres
+          resources:
+            limits:
+              cpu: 20m
+              memory: 32Mi
+            requests:
+              cpu: 5m
+              memory: 16Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: myapp
+    application: e2e-branch-42-sample-kosko
+    component: e2e-branch-42-sample-kosko
+    owner: sample-kosko
+    team: sample-kosko
+    cert: wildcard
+  name: myapp
+  annotations:
+    kapp.k14s.io/disable-default-ownership-label-rules: ''
+    kapp.k14s.io/disable-default-label-scoping-rules: ''
+    kapp.k14s.io/delete-strategy: orphan
+    app.gitlab.com/app: socialgouv-sample-kosko
+    app.gitlab.com/env: e2e-branch-42
+    app.gitlab.com/env.name: preprod-dev2
+  namespace: sample-kosko-24-e2e-branch-42
+spec:
+  ports:
+    - name: http
+      port: 80
+      targetPort: 3000
+  selector:
+    app: myapp
+  type: ClusterIP
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    kapp.k14s.io/disable-default-ownership-label-rules: ''
+    kapp.k14s.io/disable-default-label-scoping-rules: ''
+    kapp.k14s.io/delete-strategy: orphan
+    app.gitlab.com/app: socialgouv-sample-kosko
+    app.gitlab.com/env: e2e-branch-42
+    app.gitlab.com/env.name: preprod-dev2
+  labels:
+    app: myapp
+    application: e2e-branch-42-sample-kosko
+    component: e2e-branch-42-sample-kosko
+    owner: sample-kosko
+    team: sample-kosko
+    cert: wildcard
+  name: myapp
+  namespace: sample-kosko-24-e2e-branch-42
+spec:
+  rules:
+    - host: preprod-sample-kosko.dev2.fabrique.social.gouv.fr
+      http:
+        paths:
+          - backend:
+              service:
+                name: myapp
+                port:
+                  name: http
+            path: /
+            pathType: Prefix
+  tls:
+    - hosts:
+        - preprod-sample-kosko.dev2.fabrique.social.gouv.fr
+      secretName: wildcard-crt
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: netpol-sample-kosko-24-e2e-branch-42
+  namespace: sample-kosko-24-e2e-branch-42
+spec:
+  ingress:
+    - from:
+        - podSelector: {}
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: ingress-controller
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: monitoring
+  podSelector: {}
+  policyTypes:
+    - Ingress"
+`;

--- a/e2e/templates/autodevops/pg/__tests__/__snapshots__/kosko generate --env prod.ts.snap
+++ b/e2e/templates/autodevops/pg/__tests__/__snapshots__/kosko generate --env prod.ts.snap
@@ -1,0 +1,196 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`azurepg: kosko generate --prod 1`] = `
+"---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kapp.k14s.io/disable-default-ownership-label-rules: ''
+    kapp.k14s.io/disable-default-label-scoping-rules: ''
+    kapp.k14s.io/delete-strategy: orphan
+    app.gitlab.com/app: socialgouv-sample-kosko
+    app.gitlab.com/env: e2e-branch-42
+    app.gitlab.com/env.name: e2e-branch-dev2
+  labels:
+    app: myapp
+    application: sample-kosko
+    component: sample-kosko
+    owner: sample-kosko
+    team: sample-kosko
+    cert: wildcard
+  name: myapp
+  namespace: sample-kosko
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: myapp
+  template:
+    metadata:
+      annotations:
+        kapp.k14s.io/disable-default-ownership-label-rules: ''
+        kapp.k14s.io/disable-default-label-scoping-rules: ''
+        kapp.k14s.io/delete-strategy: orphan
+        app.gitlab.com/app: socialgouv-sample-kosko
+        app.gitlab.com/env: e2e-branch-42
+        app.gitlab.com/env.name: e2e-branch-dev2
+      labels:
+        app: myapp
+        application: sample-kosko
+        component: sample-kosko
+        owner: sample-kosko
+        team: sample-kosko
+        cert: wildcard
+    spec:
+      containers:
+        - image: >-
+            harbor.fabrique.social.gouv.fr/undefined/myapp:8843083edb7f873cad1d1420731a60773594ffae
+          livenessProbe:
+            failureThreshold: 6
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 5
+            timeoutSeconds: 5
+          name: myapp
+          ports:
+            - containerPort: 3000
+              name: http
+          readinessProbe:
+            failureThreshold: 15
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 0
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 200m
+              memory: 256Mi
+            requests:
+              cpu: 50m
+              memory: 128Mi
+          startupProbe:
+            failureThreshold: 12
+            httpGet:
+              path: /healthz
+              port: http
+            periodSeconds: 5
+          envFrom:
+            - secretRef:
+                name: some-pg-prefix
+          env:
+            - name: APP_BASE_URL
+              value: https://sample-kosko.dev2.fabrique.social.gouv.fr
+            - name: NEXTAUTH_URL
+              value: https://sample-kosko.dev2.fabrique.social.gouv.fr
+      initContainers:
+        - env:
+            - name: WAIT_FOR_RETRIES
+              value: '24'
+          envFrom:
+            - secretRef:
+                name: some-pg-prefix
+          image: ghcr.io/socialgouv/docker/wait-for-postgres:6.56.1
+          imagePullPolicy: Always
+          name: wait-for-postgres
+          resources:
+            limits:
+              cpu: 20m
+              memory: 32Mi
+            requests:
+              cpu: 5m
+              memory: 16Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: myapp
+    application: sample-kosko
+    component: sample-kosko
+    owner: sample-kosko
+    team: sample-kosko
+    cert: wildcard
+  name: myapp
+  annotations:
+    kapp.k14s.io/disable-default-ownership-label-rules: ''
+    kapp.k14s.io/disable-default-label-scoping-rules: ''
+    kapp.k14s.io/delete-strategy: orphan
+    app.gitlab.com/app: socialgouv-sample-kosko
+    app.gitlab.com/env: e2e-branch-42
+    app.gitlab.com/env.name: e2e-branch-dev2
+  namespace: sample-kosko
+spec:
+  ports:
+    - name: http
+      port: 80
+      targetPort: 3000
+  selector:
+    app: myapp
+  type: ClusterIP
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    kubernetes.io/tls-acme: 'true'
+    kapp.k14s.io/disable-default-ownership-label-rules: ''
+    kapp.k14s.io/disable-default-label-scoping-rules: ''
+    kapp.k14s.io/delete-strategy: orphan
+    app.gitlab.com/app: socialgouv-sample-kosko
+    app.gitlab.com/env: e2e-branch-42
+    app.gitlab.com/env.name: e2e-branch-dev2
+  labels:
+    app: myapp
+    application: sample-kosko
+    component: sample-kosko
+    owner: sample-kosko
+    team: sample-kosko
+    cert: wildcard
+  name: myapp
+  namespace: sample-kosko
+spec:
+  rules:
+    - host: sample-kosko.dev2.fabrique.social.gouv.fr
+      http:
+        paths:
+          - backend:
+              service:
+                name: myapp
+                port:
+                  name: http
+            path: /
+            pathType: Prefix
+  tls:
+    - hosts:
+        - sample-kosko.dev2.fabrique.social.gouv.fr
+      secretName: myapp-crt
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: netpol-sample-kosko
+  namespace: sample-kosko
+spec:
+  ingress:
+    - from:
+        - podSelector: {}
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: ingress-controller
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: monitoring
+  podSelector: {}
+  policyTypes:
+    - Ingress"
+`;

--- a/e2e/templates/autodevops/pg/__tests__/config.json
+++ b/e2e/templates/autodevops/pg/__tests__/config.json
@@ -1,0 +1,5 @@
+{
+  "name": "myapp",
+  "type": "app",
+  "pg": true
+}

--- a/e2e/templates/autodevops/pg/__tests__/kosko generate --env dev.ts
+++ b/e2e/templates/autodevops/pg/__tests__/kosko generate --env dev.ts
@@ -1,0 +1,35 @@
+//
+
+import { config } from "dotenv";
+import { KOSKO_BIN, template, TIMEOUT } from "e2e/templates/helpers";
+import execa from "execa";
+import { basename, resolve } from "path";
+
+//
+
+const cwd = template(basename(resolve(__dirname, "..", "..")));
+
+test(
+  "azurepg: kosko generate --dev",
+  async () => {
+    const gitlabEnv = config({
+      path: resolve(cwd, "./environments/.gitlab-ci.env"),
+    }).parsed;
+
+    const env = {
+      ...gitlabEnv,
+      SOCIALGOUV_CONFIG_PATH: __dirname + "/config.json",
+      PG_USER_SECRET_PREFIX: "some-pg-prefix",
+    };
+
+    // Required to allow seemless integration code example
+    const result = await execa.node(KOSKO_BIN, ["generate", "--env", "dev"], {
+      cwd,
+      env,
+    });
+
+    expect(result.stdout).toMatchSnapshot();
+    expect(result.exitCode).toEqual(0);
+  },
+  TIMEOUT
+);

--- a/e2e/templates/autodevops/pg/__tests__/kosko generate --env preprod.ts
+++ b/e2e/templates/autodevops/pg/__tests__/kosko generate --env preprod.ts
@@ -1,0 +1,33 @@
+import { config } from "dotenv";
+import { KOSKO_BIN, template, TIMEOUT } from "e2e/templates/helpers";
+import execa from "execa";
+import { basename, resolve } from "path";
+
+const cwd = template(basename(resolve(__dirname, "..", "..")));
+
+test(
+  "azurepg: kosko generate --preprod",
+  async () => {
+    const gitlabEnv = config({
+      path: resolve(cwd, "./environments/.gitlab-ci.env"),
+    }).parsed;
+
+    const env = {
+      ...gitlabEnv,
+      CI_ENVIRONMENT_NAME: "preprod-dev2",
+      SOCIALGOUV_CONFIG_PATH: __dirname + "/config.json",
+      PG_USER_SECRET_PREFIX: "some-pg-prefix",
+    };
+
+    // Required to allow seemless integration code example
+    const result = await execa.node(
+      KOSKO_BIN,
+      ["generate", "--env", "preprod"],
+      { cwd, env }
+    );
+
+    expect(result.stdout).toMatchSnapshot();
+    expect(result.exitCode).toEqual(0);
+  },
+  TIMEOUT
+);

--- a/e2e/templates/autodevops/pg/__tests__/kosko generate --env prod.ts
+++ b/e2e/templates/autodevops/pg/__tests__/kosko generate --env prod.ts
@@ -1,0 +1,32 @@
+import { config } from "dotenv";
+import { KOSKO_BIN, template, TIMEOUT } from "e2e/templates/helpers";
+import execa from "execa";
+import { basename, resolve } from "path";
+
+const cwd = template(basename(resolve(__dirname, "..", "..")));
+
+test(
+  "azurepg: kosko generate --prod",
+  async () => {
+    const gitlabEnv = config({
+      path: resolve(cwd, "./environments/.gitlab-ci.env"),
+    }).parsed;
+
+    const env = {
+      ...gitlabEnv,
+      PRODUCTION: "true",
+      SOCIALGOUV_CONFIG_PATH: __dirname + "/config.json",
+      PG_USER_SECRET_PREFIX: "some-pg-prefix",
+    };
+
+    // Required to allow seemless integration code example
+    const result = await execa.node(KOSKO_BIN, ["generate", "--env", "prod"], {
+      cwd,
+      env,
+    });
+
+    expect(result.stdout).toMatchSnapshot();
+    expect(result.exitCode).toEqual(0);
+  },
+  TIMEOUT
+);

--- a/templates/autodevops/components/app.ts
+++ b/templates/autodevops/components/app.ts
@@ -24,6 +24,7 @@ export default async (): Manifests => {
     probesPath,
     resources,
     azurepg,
+    pg,
     hasura,
     ingress,
     registry = "harbor",
@@ -62,7 +63,7 @@ export default async (): Manifests => {
       config: {
         containerPort: containerPort ?? 3000,
         subdomain,
-        withPostgres: azurepg && !hasura,
+        withPostgres: (pg || azurepg) && !hasura,
       },
       deployment: {
         container: {

--- a/templates/autodevops/components/pg.ts
+++ b/templates/autodevops/components/pg.ts
@@ -12,6 +12,7 @@ import Config from "../utils/config";
 export default async (): Promise<{ kind: string }[] | Manifest[]> => {
   const { azurepg, pgHostDev } = await Config();
   const ciEnv = environments(process.env);
+  // only run create-db job in dev and when azurepg is true
   if (!azurepg) {
     return [];
   }

--- a/templates/autodevops/utils/config.ts
+++ b/templates/autodevops/utils/config.ts
@@ -19,6 +19,9 @@ interface ConfigTypes {
   /** force deployment sudomain */
   subdomain: string;
   hasura?: Hasura | boolean | "exposed";
+  /** Add `pg-user` secretRef to container and wait-for-pg initContainer environments. */
+  pg?: boolean;
+  /** Add `azure-pg-user` secretRef to container and wait-for-pg initContainer environments. Also create a create-db Job in dev */
   azurepg?: boolean;
   /** define a custom pgHost for development */
   pgHostDev?: string;


### PR DESCRIPTION
In the autodevops template, `config.pg` will progressively replace the existing `azurepg` flag.

This one doesnt adds a create-db job. (it expects a previous `actions/create-db` run.)

Note: the apps attached secrets names still rely on `env.PG_USER_SECRET_PREFIX` which should now be set as `pg-user`